### PR TITLE
configure.ac: fix libv4l2 detection in static build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,7 +214,7 @@ configure --disable-video to skip building video support.])],
 configure --disable-video to skip building video support.])])])
 
 AS_IF([test "x$have_libv4l" = "xyes"],
-   AC_CHECK_LIB([v4l2], [v4l2_open], [],
+   PKG_CHECK_MODULES([V4L2], [libv4l2], [],
      [AC_MSG_FAILURE([unable to find libv4l.so])]),
   [AC_MSG_WARN([libv4l not detected. Install it to support more cameras!])])
 

--- a/zbar/Makefile.am.inc
+++ b/zbar/Makefile.am.inc
@@ -85,6 +85,10 @@ if !HAVE_VIDEO
 zbar_libzbar_la_SOURCES += zbar/video/null.c
 endif
 
+if HAVE_LIBV4L
+zbar_libzbar_la_LIBADD += $(V4L2_LIBS)
+endif
+
 if HAVE_JPEG
 zbar_libzbar_la_SOURCES += zbar/jpeg.c
 endif


### PR DESCRIPTION
When building statically zbar, build fails on:
configure: error: unable to find libv4l.so

The following errors are raised in config.log:
configure:19371: /home/buildroot/buildroot-test/instance-0/output/host/bin/arm-linux-gcc -o conftest -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2 -g2  -static -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -static conftest.c -lv4l2 -lpthread  >&5
/home/buildroot/buildroot-test/instance-0/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libv4l2.a(libv4l2_la-libv4l2.o): In function `v4l2_set_src_and_dest_format': /home/buildroot/buildroot-test/instance-0/output/build/libv4l-1.16.2/lib/libv4l2/libv4l2.c:952: undefined reference to `v4lconvert_supported_dst_format'

To fix this error, replace AC_CHECK_LIB by PKG_CHECK_MODULES to find the
correct library (-lv4lconvert but also -ljpeg, ...)

Fixes:
 - http://autobuild.buildroot.org/results/acf39e4754508d7ee49e21f08ff0a1fcac4fb7cd

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>