### PR TITLE
Add simple dbus IPC API to zbarcam.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ gtk/zbarmarshal.c
 gtk/zbarmarshal.h
 include/config.h
 include/config.h.in
+include/config.h.in~
 include/stamp-h1
 libtool
 pygtk/zbarpygtk.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,12 @@ if HAVE_DOC
 include $(srcdir)/doc/Makefile.am.inc
 endif
 
+if HAVE_DBUS
+dbusconfdir = @DBUS_CONFDIR@
+dbusconf_DATA = $(srcdir)/dbus/org.linuxtv.Zbar.conf
+EXTRA_DIST += $(dbusconf_DATA)
+endif
+
 EXTRA_DIST += zbar.ico zbar.nsi
 
 EXTRA_DIST += examples/barcode.png examples/upcrpc.py examples/upcrpc.pl \

--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,35 @@ specify XV_LIBS or configure --without-xv to disable the extension])],
 ])
 AM_CONDITIONAL([HAVE_XV], [test "x$with_xv" = "xyes"])
 
+dnl dbus
+AC_ARG_WITH([dbus],
+  [AS_HELP_STRING([--without-dbus],
+    [disable support for dbus])],
+  [],
+  [with_dbus="check"])
+
+AS_IF([test "x$with_dbus" != "xno"],
+  [PKG_CHECK_MODULES(DBUS, dbus-1 >= 1.0, have_dbus=yes, have_dbus=no)
+  AS_IF([test "x$have_dbus$with_dbus" = "xnoyes"],
+    [AC_MSG_FAILURE([DBus development libraries not found])],
+    [with_dbus="$have_dbus"])
+])
+AM_CONDITIONAL([HAVE_DBUS], [test "x$with_dbus" = "xyes"])
+
+AS_IF([test "x$with_dbus" = "xyes"],
+  [CPPFLAGS="$CPPFLAGS $DBUS_CFLAGS"
+  AC_ARG_VAR([DBUS_LIBS], [linker flags for building dbus])
+  AC_DEFINE([HAVE_DBUS], [1], [Define to 1 to use dbus])
+  AC_ARG_WITH(dbusconfdir, AC_HELP_STRING([--with-dbusconfdir=PATH],
+  [path to D-Bus config directory]),
+  [path_dbusconf=$withval],
+  [path_dbusconf="`$PKG_CONFIG --variable=sysconfdir dbus-1`"])
+  AS_IF([test -z "$path_dbusconf"],
+    DBUS_CONFDIR="$sysconfdir/dbus-1/system.d",
+    DBUS_CONFDIR="$path_dbusconf/dbus-1/system.d")
+  AC_SUBST(DBUS_CONFDIR)
+])
+
 dnl libjpeg
 AC_ARG_WITH([jpeg],
   [AS_HELP_STRING([--without-jpeg],
@@ -635,6 +664,7 @@ AS_IF([test "x$enable_video" != "xyes"],
   [echo "        => zbarcam video scanner will *NOT* be built"])
 AS_IF([test "x$have_libv4l" != "xyes"],
   [echo "        => libv4l will *NOT* be used"])
+echo "dbus              --with-dbus=$with_dbus"
 AS_IF([test "x$with_jpeg" != "xyes"],
   [echo "        => JPEG image conversions will *NOT* be supported"])
 AS_IF([test "x$have_IM" != "xyes" && test "x$have_GM" != "xyes"],

--- a/dbus/org.linuxtv.Zbar.conf
+++ b/dbus/org.linuxtv.Zbar.conf
@@ -1,0 +1,15 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <policy context="default">
+        <allow own="org.linuxtv.Zbar"/>
+        <allow send_destination="org.linuxtv.Zbar"/>
+        <allow send_destination="org.linuxtv.Zbar"
+               send_interface="org.linuxtv.Zbar1.Code"/>
+        <allow send_destination="org.linuxtv.Zbar"
+               send_interface="org.freedesktop.DBus.Properties"/>
+        <allow send_destination="org.linuxtv.Zbar"
+               send_interface="org.freedesktop.DBus.Introspectable"/>
+    </policy>
+</busconfig>

--- a/include/zbar.h
+++ b/include/zbar.h
@@ -986,6 +986,14 @@ extern int zbar_process_one(zbar_processor_t *processor,
 extern int zbar_process_image(zbar_processor_t *processor,
                               zbar_image_t *image);
 
+/** enable dbus IPC API.
+ * @returns 0 succesful
+ */
+#ifdef HAVE_DBUS
+int zbar_processor_request_dbus (zbar_processor_t *proc,
+                                 int req_dbus_enabled);
+#endif
+
 /** display detail for last processor error to stderr.
  * @returns a non-zero value suitable for passing to exit()
  */

--- a/zbar/Makefile.am.inc
+++ b/zbar/Makefile.am.inc
@@ -114,5 +114,9 @@ zbar_libzbar_la_SOURCES += zbar/processor/null.c zbar/window/null.c
 endif
 endif
 
+if HAVE_DBUS
+zbar_libzbar_la_LDFLAGS += $(DBUS_LIBS)
+endif
+
 zbar_libzbar_la_LDFLAGS += $(AM_LDFLAGS)
 zbar_libzbar_la_LIBADD += $(AM_LIBADD)

--- a/zbar/processor.c
+++ b/zbar/processor.c
@@ -25,6 +25,10 @@
 #include "window.h"
 #include "image.h"
 
+#ifdef HAVE_DBUS
+#include <dbus/dbus.h>
+#endif
+
 static inline int proc_enter (zbar_processor_t *proc)
 {
     _zbar_mutex_lock(&proc->mutex);
@@ -48,6 +52,92 @@ static inline int proc_open (zbar_processor_t *proc)
     }
     return(_zbar_processor_open(proc, "zbar barcode reader", width, height));
 }
+
+#ifdef HAVE_DBUS
+static void zbar_send_dbus(const char* sigvalue)
+{
+    DBusMessage* msg;
+    DBusMessageIter args;
+    DBusConnection* conn;
+    DBusError err;
+    int ret;
+    dbus_uint32_t serial = 0;
+
+    // initialise the error value
+    dbus_error_init(&err);
+
+    // connect to the DBUS system bus, and check for errors
+    conn = dbus_bus_get(DBUS_BUS_SYSTEM, &err);
+    if (dbus_error_is_set(&err)) {
+        fprintf(stderr, "Connection Error (%s)\n", err.message);
+        dbus_error_free(&err);
+    }
+    if (NULL == conn) {
+        fprintf(stderr, "Connection Null\n");
+        return;
+    }
+
+    // register our name on the bus, and check for errors
+    ret = dbus_bus_request_name(conn, "org.linuxtv.Zbar", DBUS_NAME_FLAG_REPLACE_EXISTING, &err);
+    if (dbus_error_is_set(&err)) {
+        fprintf(stderr, "Name Error (%s)\n", err.message);
+        dbus_error_free(&err);
+    }
+    if (DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER != ret) {
+        return;
+    }
+
+    // create a signal & check for errors
+    msg = dbus_message_new_signal("/org/linuxtv/Zbar1/Code", // object name of the signal
+                                 "org.linuxtv.Zbar1.Code", // interface name of the signal
+                                 "Code"); // name of the signal
+    if (NULL == msg)
+    {
+        fprintf(stderr, "Message Null\n");
+        return;
+    }
+
+    // append arguments onto signal
+    dbus_message_iter_init_append(msg, &args);
+    if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &sigvalue)) {
+        fprintf(stderr, "Out Of Memory!\n");
+        dbus_message_unref(msg);
+        return;
+    }
+
+    // send the message and flush the connection
+    if (!dbus_connection_send(conn, msg, &serial)) {
+        fprintf(stderr, "Out Of Memory!\n");
+        dbus_message_unref(msg);
+        return;
+    }
+    dbus_connection_flush(conn);
+    dbus_bus_release_name(conn, "org.linuxtv.Zbar", &err);
+    if (dbus_error_is_set(&err)) {
+        fprintf(stderr, "Name Release Error (%s)\n", err.message);
+        dbus_error_free(&err);
+    }
+
+    // free the message
+    dbus_message_unref(msg);
+}
+
+static void zbar_send_code_via_dbus (zbar_image_t *img)
+{
+    const zbar_symbol_t *sym = zbar_image_first_symbol(img);
+    assert(sym);
+    for(; sym; sym = zbar_symbol_next(sym)) {
+        if(zbar_symbol_get_count(sym))
+            continue;
+
+        zbar_symbol_type_t type = zbar_symbol_get_type(sym);
+        if(type == ZBAR_PARTIAL)
+            continue;
+
+        zbar_send_dbus(zbar_symbol_get_data(sym));
+    }
+}
+#endif
 
 /* API lock is already held */
 int _zbar_process_image (zbar_processor_t *proc,
@@ -114,6 +204,10 @@ int _zbar_process_image (zbar_processor_t *proc,
             _zbar_mutex_unlock(&proc->mutex);
             if(proc->handler)
                 proc->handler(img, proc->userdata);
+#ifdef HAVE_DBUS
+            if(proc->is_dbus_enabled)
+                zbar_send_code_via_dbus(img);
+#endif
         }
 
         if(force_fmt) {
@@ -711,3 +805,14 @@ int zbar_process_image (zbar_processor_t *proc,
     proc_leave(proc);
     return(rc);
 }
+
+#ifdef HAVE_DBUS
+int zbar_processor_request_dbus (zbar_processor_t *proc,
+                                 int req_dbus_enabled)
+{
+    proc_enter(proc);
+    proc->is_dbus_enabled = req_dbus_enabled;
+    proc_leave(proc);
+    return(0);
+}
+#endif

--- a/zbar/processor.h
+++ b/zbar/processor.h
@@ -69,6 +69,10 @@ struct zbar_processor_s {
 
     zbar_image_data_handler_t *handler; /* application data handler */
 
+#ifdef HAVE_DBUS
+    int is_dbus_enabled;                /* dbus enabled flag */
+#endif
+
     unsigned req_width, req_height;     /* application requested video size */
     int req_intf, req_iomode;           /* application requested interface */
     uint32_t force_input;               /* force input format (debug) */

--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -48,6 +48,9 @@ static const char *note_usage =
     "    --verbose=N     set specific debug output level\n"
     "    --xml           use XML output format\n"
     "    --raw           output decoded symbol data without symbology prefix\n"
+#ifdef HAVE_DBUS
+    "    --nodbus        disable dbus message\n"
+#endif
     "    --nodisplay     disable video display window\n"
     "    --prescale=<W>x<H>\n"
     "                    request alternate video image size from driver\n"
@@ -150,6 +153,9 @@ int main (int argc, const char *argv[])
     zbar_processor_set_data_handler(proc, data_handler, NULL);
 
     const char *video_device = "";
+#ifdef HAVE_DBUS
+    int dbus = 1;
+#endif
     int display = 1;
     unsigned long infmt = 0, outfmt = 0;
     int i;
@@ -203,6 +209,10 @@ int main (int argc, const char *argv[])
             format = XML;
         else if(!strcmp(argv[i], "--raw"))
             format = RAW;
+#ifdef HAVE_DBUS
+        else if(!strcmp(argv[i], "--nodbus"))
+            dbus = 0;
+#endif
         else if(!strcmp(argv[i], "--nodisplay"))
             display = 0;
         else if(!strcmp(argv[i], "--verbose"))
@@ -246,6 +256,10 @@ int main (int argc, const char *argv[])
 
     if(infmt || outfmt)
         zbar_processor_force_format(proc, infmt, outfmt);
+
+#ifdef HAVE_DBUS
+    zbar_processor_request_dbus(proc, dbus);
+#endif
 
     /* open video device, open window */
     if(zbar_processor_init(proc, video_device, display) ||

--- a/zbarimg/zbarimg.c
+++ b/zbarimg/zbarimg.c
@@ -74,6 +74,9 @@ static const char *note_usage =
     "    -q, --quiet     minimal output, only print decoded symbol data\n"
     "    -v, --verbose   increase debug output level\n"
     "    --verbose=N     set specific debug output level\n"
+#ifdef HAVE_DBUS
+    "    --nodbus        disable dbus message\n"
+#endif
     "    -d, --display   enable display of following images to the screen\n"
     "    -D, --nodisplay disable display of following images (default)\n"
     "    --xml, --noxml  enable/disable XML output format\n"
@@ -291,6 +294,9 @@ int main (int argc, const char *argv[])
 {
     // option pre-scan
     int quiet = 0;
+#ifdef HAVE_DBUS
+    int dbus = 1;
+#endif
     int display = 0;
     int i, j;
     for(i = 1; i < argc; i++) {
@@ -331,6 +337,10 @@ int main (int argc, const char *argv[])
             zbar_increase_verbosity();
         else if(!strncmp(arg, "--verbose=", 10))
             zbar_set_verbosity(strtol(argv[i] + 10, NULL, 0));
+#ifdef HAVE_DBUS
+        else if(!strcmp(arg, "--nodbus"))
+            dbus = 0;
+#endif
         else if(!strcmp(arg, "--display"))
             display++;
         else if(!strcmp(arg, "--nodisplay") ||
@@ -356,6 +366,11 @@ int main (int argc, const char *argv[])
 
     processor = zbar_processor_create(0);
     assert(processor);
+
+#ifdef HAVE_DBUS
+    zbar_processor_request_dbus(processor, dbus);
+#endif
+
     if(zbar_processor_init(processor, NULL, display)) {
         zbar_processor_error_spew(processor, 0);
         return(1);


### PR DESCRIPTION
This is useful for running zbarcam as a systemd service so that other
applications can receive scan messages through dbus.
