### PR TITLE
Add support for inverted codes

### DIFF
--- a/zbar/image.c
+++ b/zbar/image.c
@@ -207,9 +207,24 @@ zbar_image_t *zbar_image_copy (const zbar_image_t *src)
     dst->datalen = src->datalen;
     dst->data = malloc(src->datalen);
     assert(dst->data);
+    dst->inverted = src->inverted;
     memcpy((void*)dst->data, src->data, src->datalen);
     dst->cleanup = zbar_image_free_data;
     return(dst);
+}
+
+void zbar_image_invert(const zbar_image_t *img)
+{
+    zbar_image_t *rw = (zbar_image_t *) img;
+    uint8_t *rwdata = (uint8_t *)img->data;
+    const uint8_t *input = (const uint8_t *)img->data;
+    int i;
+    assert(
+        img->format == fourcc('Y','8','0','0') ||
+        img->format == fourcc('G','R','E','Y') );
+    rw->inverted = ! img->inverted;
+    for (i=0; i<img->datalen; i++)
+        rwdata[i] = ~ input[i];
 }
 
 const zbar_symbol_set_t *zbar_image_get_symbols (const zbar_image_t *img)

--- a/zbar/image.h
+++ b/zbar/image.h
@@ -65,6 +65,7 @@ struct zbar_image_s {
     unsigned crop_x, crop_y;    /* crop rectangle */
     unsigned crop_w, crop_h;
     void *userdata;             /* user specified data associated w/image */
+    int inverted;               /* is the picture inverted? */
 
     /* cleanup handler */
     zbar_image_cleanup_handler_t *cleanup;
@@ -100,6 +101,8 @@ typedef struct zbar_format_def_s {
 
 
 extern int _zbar_best_format(uint32_t, uint32_t*, const uint32_t*);
+extern void zbar_image_invert(const zbar_image_t *src);
+extern void zbar_image_invert(const zbar_image_t *src);
 extern const zbar_format_def_t *_zbar_format_lookup(uint32_t);
 extern void _zbar_image_free(zbar_image_t*);
 

--- a/zbar/img_scanner.c
+++ b/zbar/img_scanner.c
@@ -925,6 +925,15 @@ int zbar_scan_image (zbar_image_scanner_t *iscn,
         iscn->handler(img, iscn->userdata);
 
     svg_close();
+    if ( (syms->nsyms==0) && (! img->inverted) )
+        {
+            int r;
+            // zbar_image_t *img_inverted = zbar_image_copy(img, 1);
+            zbar_image_invert(img);
+            r = zbar_scan_image (iscn, img);
+            //zbar_image_free_data( img_inverted );
+            return(r);
+        }
     return(syms->nsyms);
 }
 


### PR DESCRIPTION
This patch enables zbar to scan inverted codes, especially helpful for QR-Codes that some people seem to like printing inverted.