### PR TITLE
Support inverted, 2nd try

### DIFF
--- a/debian/libzbar0.symbols
+++ b/debian/libzbar0.symbols
@@ -40,6 +40,7 @@ libzbar.so.0 libzbar0 #MINVER#
  zbar_image_get_symbols@Base 0.10
  zbar_image_get_userdata@Base 0.10
  zbar_image_get_width@Base 0.10
+ zbar_image_invert@Base 0.21
  zbar_image_ref@Base 0.10
  zbar_image_scanner_create@Base 0.10
  zbar_image_scanner_destroy@Base 0.10

--- a/zbar/image.c
+++ b/zbar/image.c
@@ -207,9 +207,25 @@ zbar_image_t *zbar_image_copy (const zbar_image_t *src)
     dst->datalen = src->datalen;
     dst->data = malloc(src->datalen);
     assert(dst->data);
+    dst->inverted = src->inverted;
     memcpy((void*)dst->data, src->data, src->datalen);
     dst->cleanup = zbar_image_free_data;
     return(dst);
+}
+
+ 
+void zbar_image_invert(const zbar_image_t *img)
+{
+    zbar_image_t *rw = (zbar_image_t *) img;
+    uint8_t *rwdata = (uint8_t *)img->data;
+    const uint8_t *input = (const uint8_t *)img->data;
+    int i;
+    assert(
+        img->format == fourcc('Y','8','0','0') ||
+        img->format == fourcc('G','R','E','Y') );
+    rw->inverted = ! img->inverted;
+    for (i=0; i<img->datalen; i++)
+        rwdata[i] = ~ input[i];
 }
 
 const zbar_symbol_set_t *zbar_image_get_symbols (const zbar_image_t *img)

--- a/zbar/image.h
+++ b/zbar/image.h
@@ -65,6 +65,7 @@ struct zbar_image_s {
     unsigned crop_x, crop_y;    /* crop rectangle */
     unsigned crop_w, crop_h;
     void *userdata;             /* user specified data associated w/image */
+    int inverted;               /* is the picture inverted? */
 
     /* cleanup handler */
     zbar_image_cleanup_handler_t *cleanup;

--- a/zbar/image.h
+++ b/zbar/image.h
@@ -100,10 +100,7 @@ typedef struct zbar_format_def_s {
 
 
 extern int _zbar_best_format(uint32_t, uint32_t*, const uint32_t*);
-<<<<<<< HEAD
-=======
 extern void zbar_image_invert(const zbar_image_t *src);
->>>>>>> Try inversion in image_processor not scan_image
 extern const zbar_format_def_t *_zbar_format_lookup(uint32_t);
 extern void _zbar_image_free(zbar_image_t*);
 

--- a/zbar/image.h
+++ b/zbar/image.h
@@ -100,6 +100,10 @@ typedef struct zbar_format_def_s {
 
 
 extern int _zbar_best_format(uint32_t, uint32_t*, const uint32_t*);
+<<<<<<< HEAD
+=======
+extern void zbar_image_invert(const zbar_image_t *src);
+>>>>>>> Try inversion in image_processor not scan_image
 extern const zbar_format_def_t *_zbar_format_lookup(uint32_t);
 extern void _zbar_image_free(zbar_image_t*);
 

--- a/zbar/processor.c
+++ b/zbar/processor.c
@@ -219,6 +219,11 @@ int _zbar_process_image (zbar_processor_t *proc,
         }
         zbar_image_scanner_recycle_image(proc->scanner, img);
         int nsyms = zbar_scan_image(proc->scanner, tmp);
+        if (nsyms == 0)
+        {
+            zbar_image_invert(tmp);
+            int nsyms = zbar_scan_image(proc->scanner, tmp);
+        }
         _zbar_image_swap_symbols(img, tmp);
 
         zbar_image_destroy(tmp);

--- a/zbar/processor.c
+++ b/zbar/processor.c
@@ -222,7 +222,7 @@ int _zbar_process_image (zbar_processor_t *proc,
         if (nsyms == 0)
         {
             zbar_image_invert(tmp);
-            int nsyms = zbar_scan_image(proc->scanner, tmp);
+            nsyms = zbar_scan_image(proc->scanner, tmp);
         }
         _zbar_image_swap_symbols(img, tmp);
 


### PR DESCRIPTION
Hi there,
I moved the retrying code into processor.c where it seems to also make kind of sense.
It does not seem to break tests anymore but zbarimg and zbarcam recognize both inverted and non inverted codes.
