### PR TITLE
Exit gracefully when decoding split QR codes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+zbar (0.21.1) unstable; urgency=low
+
+  * New upstream release.
+  * Exit gracefully when decoding split QR codes. (Closes: #719013)
+
+ -- Javier Serrano Polo <javier@jasp.net>  Wed, 13 Feb 2019 10:03:35 +0100
+
 zbar (0.21) unstable; urgency=low
 
   * New upstream release.

--- a/zbar/qrcode/qrdectxt.c
+++ b/zbar/qrcode/qrdectxt.c
@@ -454,8 +454,12 @@ int qr_code_data_list_extract_text(const qr_code_data_list *_qrlist,
                   }
               syms->data = sa_text + syms->datalen;
               next = (syms->next) ? syms->next->datalen : sa_ntext;
-              assert(next > syms->datalen);
-              syms->datalen = next - syms->datalen - 1;
+              if (next > syms->datalen)
+                  syms->datalen = next - syms->datalen - 1;
+              else {
+                  zprintf(1, "Assertion `next > syms->datalen' failed\n");
+                  syms->datalen = 0;
+              }
           }
           if(xmax >= -1) {
               sym_add_point(sa_sym, xmin, ymin);

--- a/zbarimg/zbarimg.c
+++ b/zbarimg/zbarimg.c
@@ -125,6 +125,8 @@ static const char *warning_not_found =
     "  - is the barcode large enough in the image?\n"
     "  - is the barcode mostly in focus?\n"
     "  - is there sufficient contrast/illumination?\n"
+    "  - If the symbol is split in several barcodes, are they combined in one "
+    "image?\n"
     "  - Did you enable the barcode type?\n"
     "    some EAN/UPC codes are disabled by default. To enable all, use:\n"
     "    $ zbarimg -S*.enable <files>\n"


### PR DESCRIPTION
As discussed in #24, ZBar should not support QR codes split in different images.

Closes #24.