### PR TITLE
Close Debian #762114

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 zbar (0.21.1) unstable; urgency=low
 
-  * New upstream release.
+  * New upstream release. (Closes: #762114)
   * Exit gracefully when decoding split QR codes. (Closes: #719013)
 
  -- Javier Serrano Polo <javier@jasp.net>  Wed, 13 Feb 2019 10:03:35 +0100


### PR DESCRIPTION
Regarding Debian [#762114](https://bugs.debian.org/762114), I have run `zbarcam` without problems. Current version should not have the reported bug.