### PR TITLE
Fix typos found by codespell.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,7 +21,7 @@
   * Ignore ENOTTY errors when calling VIDIOC_S_CROP
   * doc/Makefile.am.inc: clean html generated files
   * Add --disable-doc configure option to disable building docs
-  * Fix function protoype to be compatible with recent libjpeg
+  * Fix function prototype to be compatible with recent libjpeg
   * Wrap logical not operations into parentheses
   * INSTALL: warn that autoconf should be called before configure
   * code128: fix error logic

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ code images and using a video device (eg, webcam) as a bar code scanner.
 For application developers, language bindings are included for C, C++,
 Python 2 and Perl as well as GUI widgets for Qt, GTK and PyGTK 2.0.
 
-Zbar also supports sending the scaned codes via dbus, allowing its
+Zbar also supports sending the scanned codes via dbus, allowing its
 integration with other applications.
 
 Check the ZBar home page for the latest release, mailing lists, etc.:
@@ -27,7 +27,7 @@ BUILDING
 See `INSTALL.md` for generic configuration and build instructions.
 
 The scanner/decoder library itself only requires a few standard
-library functions which should be avilable almost anywhere.
+library functions which should be available almost anywhere.
 
 The zbarcam program uses the video4linux API (v4l1 or v4l2) to access
 the video device.  This interface is part of the linux kernel, a 3.16

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ LT_INIT([dlopen win32-dll])
 LT_LANG([Windows Resource])
 AM_SILENT_RULES([yes])
 
-dnl update these just before each release (along w/pacakge version above)
+dnl update these just before each release (along w/package version above)
 dnl   LIB_VERSION update instructions copied from libtool docs:
 dnl   library version follows the form current:revision:age
 dnl   - If the library source code has changed at all since the last update,
@@ -404,7 +404,7 @@ AS_IF([test "x$with_imagemagick" = "xno"], [],
      [MAGICK_VERSION=`$PKG_CONFIG MagickWand --modversion`],
      [dnl
 dnl Wand is deprecated in favor of MagickWand,
-dnl but the latter doesn't exist in older verisons (bug #2848437)
+dnl but the latter doesn't exist in older versions (bug #2848437)
       saved_error=$MAGICK_PKG_ERRORS
       PKG_CHECK_MODULES([MAGICK], [Wand >= 6.2.6],
         [MAGICK_VERSION=`$PKG_CONFIG Wand --modversion`],

--- a/iphone/ChangeLog
+++ b/iphone/ChangeLog
@@ -8,7 +8,7 @@ version 1.3.1:
   * Lion and Xcode updates
     - fix new warnings/errors
     - find missing buddy
-    - fix SDK bg image: force resoution to 72dpi
+    - fix SDK bg image: force resolution to 72dpi
   * Fix EmbedReader example rotation interaction
 
 version 1.2.2:

--- a/iphone/doc/ZBarReaderViewController.rst
+++ b/iphone/doc/ZBarReaderViewController.rst
@@ -152,7 +152,7 @@ Class Methods
 
       Returns an array with the single element
       ``UIImagePickerControllerCameraCaptureModeVideo`` if the device is
-      avilable, otherwise returns an empty array.
+      available, otherwise returns an empty array.
 
 
 Instance Methods

--- a/iphone/doc/licensing.rst
+++ b/iphone/doc/licensing.rst
@@ -144,7 +144,7 @@ Additionally, to avoid "casual requests" from nefarious types that just want
 to inconvenience you, also consider charging a fee for the distribution of
 this material (as permitted by the license); just add up the cost of burning
 and shipping a disk.  If this cost is "large" compared to the price of your
-app, the likelyhood of a request is reduced even further.
+app, the likelihood of a request is reduced even further.
 
 
 Using the Unmodified Library

--- a/iphone/doc/optimizing.rst
+++ b/iphone/doc/optimizing.rst
@@ -161,7 +161,7 @@ default setting.
 
 For some devices, the "torch" can be enabled to provide additional
 illumination for the camera in low-light conditions.  The reader sets the
-torch to automatic by default, so it should turn on only when needeed...
+torch to automatic by default, so it should turn on only when needed...
 There have been some reports that the torch turns on inappropriately, washing
 out the image.  If you find that this occurs, you should instead set the
 :member:`~ZBarReaderView::torchMode` property of the :class:`ZBarReaderView`
@@ -244,7 +244,7 @@ the image.  The density of the passes is configured at the scanner as a pixel
 stride for each axis.  ``ZBAR_CFG_Y_DENSITY`` (``ZBAR_CFG_X_DENSITY``)
 controls the number of pixel rows (columns) that are skipped between
 successive horizontal (vertical) scan passes.  (Note that "density" is really
-not a good name for the configuation settings... "stride" might be more
+not a good name for the configuration settings... "stride" might be more
 appropriate.)
 
 Decreasing the scan density (by increasing the stride setting) is a great way

--- a/perl/ZBar/Processor.pod
+++ b/perl/ZBar/Processor.pod
@@ -57,7 +57,7 @@ video and to optionally display a video/image preview to a window.
 This interface is not well suited for integration with an existing
 GUI, as the library manages the optional preview window and any user
 interaction.  Use a Barcode::ZBar::ImageScanner or Investigate the
-avilable widget interfaces for GUI applications.
+available widget interfaces for GUI applications.
 
 =head1 REFERENCE
 

--- a/perl/ZBar/Symbol.pod
+++ b/perl/ZBar/Symbol.pod
@@ -91,7 +91,7 @@ A negative value indicates that this result is still uncertain
 
 =item *
 
-A zero value indicates the first occurance of this result with high
+A zero value indicates the first occurrence of this result with high
 confidence
 
 =item *

--- a/perl/inc/Devel/CheckLib.pm
+++ b/perl/inc/Devel/CheckLib.pm
@@ -114,7 +114,7 @@ incpaths, each preceded by '-I'.
 =head2 check_lib_or_exit
 
 This behaves exactly the same as C<assert_lib()> except that instead of
-dieing, it warns (with exactly the same error message) and exits.
+dying, it warns (with exactly the same error message) and exits.
 This is intended for use in Makefile.PL / Build.PL
 when you might want to prompt the user for various paths and
 things before checking that what they've told you is sane.

--- a/zbar/qrcode/rs.c
+++ b/zbar/qrcode/rs.c
@@ -392,7 +392,7 @@ static void rs_calc_syndrome(const rs_gf256 *_gf,int _m0,
   Error correction is done using the error-evaluator equation on p. 207.
   @BOOK{CC81,
     author="George C. Clark, Jr and J. Bibb Cain",
-    title="Error-Correction Coding for Digitial Communications",
+    title="Error-Correction Coding for Digital Communications",
     series="Applications of Communications Theory",
     publisher="Springer",
     address="New York, NY",

--- a/zbar/qrcode/util.c
+++ b/zbar/qrcode/util.c
@@ -32,7 +32,7 @@ unsigned qr_isqrt(unsigned _val){
 /*Computes sqrt(_x*_x+_y*_y) using CORDIC.
   This implementation is valid for all 32-bit inputs and returns a result
    accurate to about 27 bits of precision.
-  It has been tested for all postiive 16-bit inputs, where it returns correctly
+  It has been tested for all positive 16-bit inputs, where it returns correctly
    rounded results in 99.998% of cases and the maximum error is
    0.500137134862598032 (for _x=48140, _y=63018).
   Very nearly all results less than (1<<16) are correctly rounded.

--- a/zbar/video/vfw.c
+++ b/zbar/video/vfw.c
@@ -244,7 +244,7 @@ static int vfw_set_format (zbar_video_t *vdo,
     bih->biClrUsed = bih->biClrImportant = 0;
     bih->biCompression = fmt;
 
-    zprintf(8, "seting format: %.4s(%08x) " BIH_FMT "\n",
+    zprintf(8, "setting format: %.4s(%08x) " BIH_FMT "\n",
             (char*)&fmt, fmt, BIH_FIELDS(bih));
 
     if(!capSetVideoFormat(vdo->state->hwnd, bih, vdo->state->bi_size))

--- a/zbarcam/zbarcam-gtk.c
+++ b/zbarcam/zbarcam-gtk.c
@@ -52,7 +52,7 @@ static void decoded (GtkWidget *widget,
 }
 
 
-/* update botton state when video state changes
+/* update button state when video state changes
  */
 static void video_enabled (GObject *object,
                            GParamSpec *param,


### PR DESCRIPTION
Codespell (https://github.com/codespell-project/codespell/) is a great project and I discovered another bunch of typos here.