### PR TITLE
Port to python3

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ endif
 if HAVE_GTK
 include $(srcdir)/gtk/Makefile.am.inc
 pkgconfig_DATA += zbar-gtk.pc
-if HAVE_PYTHON
+if HAVE_PYGTK2
 include $(srcdir)/pygtk/Makefile.am.inc
 endif
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -477,12 +477,12 @@ AS_IF([test "x$with_gtk" != "xno"],
 
 AM_CONDITIONAL([HAVE_GTK], [test "x$with_gtk" = "xyes"])
 
-dnl PyGTK
-AC_ARG_WITH([python2],
-  [AS_HELP_STRING([--without-python2],
-    [disable support for Python 2 bindings])],
+dnl Python
+AC_ARG_WITH([python],
+  [AS_HELP_STRING([--without-python],
+    [disable support for Python bindings])],
   [],
-  [with_python2="yes"])
+  [with_python="yes"])
 
 AC_ARG_VAR([PYTHON_CONFIG], [full path to python-config program])
 AC_ARG_VAR([PYTHON_CFLAGS], [compiler flags for building python extensions])
@@ -492,17 +492,18 @@ AC_ARG_VAR([PYGTK_H2DEF], [full path to PyGTK h2def.py module])
 AC_ARG_VAR([PYGTK_CODEGEN], [full path to pygtk-codegen program])
 AC_ARG_VAR([PYGTK_DEFS], [directory where PyGTK definitions may be found])
 
-AS_IF([test "x$with_python2" != "xno"],
+AS_IF([test "x$with_python" != "xno"],
   [AM_PATH_PYTHON(2.7.0)
+   PYTHON_VERSION_MAJOR="$PYTHON -c 'import sys; sys.stdout.write(sys.version_info[0])'"
    AS_IF([test "x$PYTHON_CFLAGS" != "x"],
      [],
      [test "x$PYTHON_CONFIG" != "x" && test -x "$PYTHON_CONFIG"],
      [PYTHON_CFLAGS=`$PYTHON_CONFIG --cflags`],
      [test -x "$PYTHON-config"],
      [PYTHON_CFLAGS=`$PYTHON-config --cflags`],
-     [PYTHON_CFLAGS=`$PYTHON -c 'import distutils.sysconfig as s; print " ".join(s.get_config_vars("CFLAGS")) + " -I"+s.get_python_inc() + " -I"+s.get_python_inc(plat_specific=True)'`])
+     [PYTHON_CFLAGS=`$PYTHON -c 'import distutils.sysconfig as s, sys; sys.stdout.write(" ".join(s.get_config_vars("CFLAGS")) + " -I"+s.get_python_inc() + " -I"+s.get_python_inc(plat_specific=True))'`])
 
-dnl check that #include <Python.h> compiles (bug #3092663)
+   dnl check that #include <Python.h> compiles (bug #3092663)
    CPPFLAGS_save="$CPPFLAGS"
    CPPFLAGS="$CPPFLAGS $PYTHON_CFLAGS"
    AC_CHECK_HEADER([Python.h], [], [AC_MSG_ERROR([dnl
@@ -512,7 +513,9 @@ Install the development package for python-$am_cv_python_version, or configure
 ])])
    CPPFLAGS="$CPPFLAGS_save"
 
-   AS_IF([test "x$with_gtk" = "xyes"],
+   dnl PyGTK
+   dnl disable pygtk when we're on Python 3
+   AS_IF([test "x$with_gtk$PYTHON_VERSION_MAJOR" = "xyes2"],
      [PKG_CHECK_MODULES([PYGTK], [pygtk-2.0])
       AC_CHECK_PROGS([PYGTK_CODEGEN], [pygobject-codegen-2.0 pygtk-codegen-2.0 pygtk-codegen], [:])
 
@@ -524,7 +527,8 @@ Install the development package for python-$am_cv_python_version, or configure
    ])
 ])
 
-AM_CONDITIONAL([HAVE_PYTHON], [test "x$with_python2" = "xyes"])
+AM_CONDITIONAL([HAVE_PYTHON], [test "x$with_python" = "xyes"])
+AM_CONDITIONAL([HAVE_PYGTK2], [test "x$with_gtk$PYTHON_VERSION_MAJOR" = "xyes2"])
 
 dnl Qt
 AC_ARG_WITH([qt],
@@ -724,7 +728,7 @@ echo "pthreads          --enable-pthread=$enable_pthread"
 echo "doc               --enable-doc=$enable_doc"
 echo "v4l               --enable-video=$enable_video"
 echo "jpeg              --with-jpeg=$with_jpeg"
-echo "Python ${PYTHON_VERSION}        --with-python2=$with_python2"
+echo "Python ${PYTHON_VERSION}        --with-python=$with_python"
 echo "GTK+${GTK_VERSION}       --with-gtk=$with_gtk"
 echo "Qt${QT_VERSION}           --with-qt=$with_qt"
 echo "Java              --with-java=$with_java"
@@ -752,7 +756,7 @@ AS_IF([test "x$have_GM" = "xyes"],
   [echo "        => ImageMagick is preferred, as GraphicsMagick doesn't support https"])
 AS_IF([test "x$with_gtk" != "xyes"],
   [echo "        => the GTK+ widget will *NOT* be built"],
-  [AS_IF([test "x$with_python2" != "xyes"],
+  [AS_IF([test "x$with_python$PYTHON_VERSION_MAJOR" != "xyes2"],
      [echo "        => the PyGTK widget wrapper will *NOT* be built"])])
 AS_IF([test "x$with_qt" != "xyes"],
   [echo "        => the Qt widget will *NOT* be built"])

--- a/debian/rules
+++ b/debian/rules
@@ -62,7 +62,7 @@ build-nopython/configure-stamp: autotools-dev-stamp
 	dh_testdir
 
 	mkdir -p build-nopython
-	cd build-nopython && $(CONFIGURE) --without-python2 LDFLAGS="$(LDFLAGS_DEFAULT)"
+	cd build-nopython && $(CONFIGURE) --without-python LDFLAGS="$(LDFLAGS_DEFAULT)"
 	touch $@
 
 build-python%/configure-stamp: autotools-dev-stamp build-nopython/build-stamp

--- a/python/Makefile.am.inc
+++ b/python/Makefile.am.inc
@@ -1,7 +1,6 @@
 pyexec_LTLIBRARIES += python/zbar.la
 python_zbar_la_CPPFLAGS = $(PYTHON_CFLAGS) $(AM_CPPFLAGS)
-python_zbar_la_LDFLAGS = -shared -module -avoid-version -export-dynamic \
-    -export-symbols-regex initzbar
+python_zbar_la_LDFLAGS = -shared -module -avoid-version -export-dynamic
 python_zbar_la_LIBADD = $(PYTHON_LIBS) zbar/libzbar.la $(AM_LIBADD)
 
 python_zbar_la_SOURCES = python/zbarmodule.c python/zbarmodule.h \

--- a/python/decoder.c
+++ b/python/decoder.c
@@ -124,15 +124,24 @@ static PyObject*
 decoder_get_data (zbarDecoder *self,
                   void *closure)
 {
+#if PY_MAJOR_VERSION >= 3
+    return(PyBytes_FromStringAndSize(zbar_decoder_get_data(self->zdcode),
+                                     zbar_decoder_get_data_length(self->zdcode)));
+#else
     return(PyString_FromStringAndSize(zbar_decoder_get_data(self->zdcode),
                                       zbar_decoder_get_data_length(self->zdcode)));
+#endif
 }
 
 static PyObject*
 decoder_get_direction (zbarDecoder *self,
                        void *closure)
 {
+#if PY_MAJOR_VERSION >= 3
+    return(PyLong_FromLong(zbar_decoder_get_direction(self->zdcode)));
+#else
     return(PyInt_FromLong(zbar_decoder_get_direction(self->zdcode)));
+#endif
 }
 
 static PyGetSetDef decoder_getset[] = {

--- a/python/decoder.c
+++ b/python/decoder.c
@@ -85,7 +85,9 @@ decoder_get_color (zbarDecoder *self,
 {
     zbar_color_t zcol = zbar_decoder_get_color(self->zdcode);
     assert(zcol == ZBAR_BAR || zcol == ZBAR_SPACE);
-    zbarEnumItem *color = color_enum[zcol];
+
+    struct module_state *st = GETMODSTATE();
+    zbarEnumItem *color = st->color_enum[zcol];
     Py_INCREF((PyObject*)color);
     return(color);
 }
@@ -97,8 +99,9 @@ decoder_get_type (zbarDecoder *self,
     zbar_symbol_type_t sym = zbar_decoder_get_type(self->zdcode);
     if(sym == ZBAR_NONE) {
         /* hardcode most common case */
-        Py_INCREF((PyObject*)symbol_NONE);
-        return(symbol_NONE);
+        struct module_state *st = GETMODSTATE();
+        Py_INCREF((PyObject*)st->symbol_NONE);
+        return(st->symbol_NONE);
     }
     return(zbarSymbol_LookupEnum(sym));
 }
@@ -107,9 +110,10 @@ static PyObject*
 decoder_get_configs (zbarDecoder *self,
                      void *closure)
 {
+    struct module_state *st = GETMODSTATE();
     unsigned int sym = zbar_decoder_get_type(self->zdcode);
     unsigned int mask = zbar_decoder_get_configs(self->zdcode, sym);
-    return(zbarEnum_SetFromMask(config_enum, mask));
+    return(zbarEnum_SetFromMask(st->config_enum, mask));
 }
 
 static PyObject*
@@ -117,7 +121,8 @@ decoder_get_modifiers (zbarDecoder *self,
                        void *closure)
 {
     unsigned int mask = zbar_decoder_get_modifiers(self->zdcode);
-    return(zbarEnum_SetFromMask(modifier_enum, mask));
+    struct module_state *st = GETMODSTATE();
+    return(zbarEnum_SetFromMask(st->modifier_enum, mask));
 }
 
 static PyObject*
@@ -187,8 +192,9 @@ decoder_get_configs_meth (zbarDecoder *self,
     if(sym == ZBAR_NONE)
         sym = zbar_decoder_get_type(self->zdcode);
 
+    struct module_state *st = GETMODSTATE();
     unsigned int mask = zbar_decoder_get_configs(self->zdcode, sym);
-    return(zbarEnum_SetFromMask(config_enum, mask));
+    return(zbarEnum_SetFromMask(st->config_enum, mask));
 }
 
 static PyObject*
@@ -306,8 +312,9 @@ decoder_decode_width (zbarDecoder *self,
         return(NULL);
     if(sym == ZBAR_NONE) {
         /* hardcode most common case */
-        Py_INCREF((PyObject*)symbol_NONE);
-        return(symbol_NONE);
+        struct module_state *st = GETMODSTATE();
+        Py_INCREF((PyObject*)st->symbol_NONE);
+        return(st->symbol_NONE);
     }
     return(zbarSymbol_LookupEnum(sym));
 }

--- a/python/exception.c
+++ b/python/exception.c
@@ -23,6 +23,8 @@
 
 #include "zbarmodule.h"
 
+#if PY_MAJOR_VERSION < 3
+
 static inline PyObject*
 exc_get_message (zbarException *self,
                  void *closure)
@@ -126,20 +128,4 @@ PyTypeObject zbarException_Type = {
     .tp_getset      = exc_getset,
 };
 
-PyObject*
-zbarErr_Set (PyObject *self)
-{
-    const void *zobj = ((zbarProcessor*)self)->zproc;
-    zbar_error_t err = _zbar_get_error_code(zobj);
-
-    if(err == ZBAR_ERR_NOMEM)
-        PyErr_NoMemory();
-    else if(err < ZBAR_ERR_NUM) {
-        PyObject *type = zbar_exc[err];
-        assert(type);
-        PyErr_SetObject(type, self);
-    }
-    else
-        PyErr_SetObject(zbar_exc[0], self);
-    return(NULL);
-}
+#endif

--- a/python/imagescanner.c
+++ b/python/imagescanner.c
@@ -158,7 +158,11 @@ imagescanner_scan (zbarImageScanner *self,
         PyErr_Format(PyExc_ValueError, "unsupported image format");
         return(NULL);
     }
+#if PY_MAJOR_VERSION >= 3
+    return(PyLong_FromLong(n));
+#else
     return(PyInt_FromLong(n));
+#endif
 }
 
 static PyMethodDef imagescanner_methods[] = {

--- a/python/processor.c
+++ b/python/processor.c
@@ -244,11 +244,15 @@ static int
 object_to_timeout (PyObject *obj,
                    int *val)
 {
-    int tmp;
+    long tmp;
     if(PyFloat_Check(obj))
         tmp = PyFloat_AS_DOUBLE(obj) * 1000;
     else
+#if PY_MAJOR_VERSION >= 3
+        tmp = PyLong_AsLong(obj) * 1000;
+#else
         tmp = PyInt_AsLong(obj) * 1000;
+#endif
     if(tmp < 0 && PyErr_Occurred())
         return(0);
     *val = tmp;
@@ -273,7 +277,11 @@ processor_user_wait (zbarProcessor *self,
 
     if(rc < 0)
         return(zbarErr_Set((PyObject*)self));
+#if PY_MAJOR_VERSION >= 3
+    return(PyLong_FromLong(rc));
+#else
     return(PyInt_FromLong(rc));
+#endif
 }
 
 static PyObject*
@@ -294,7 +302,11 @@ processor_process_one (zbarProcessor *self,
 
     if(rc < 0)
         return(zbarErr_Set((PyObject*)self));
+#if PY_MAJOR_VERSION >= 3
+    return(PyLong_FromLong(rc));
+#else
     return(PyInt_FromLong(rc));
+#endif
 }
 
 static PyObject*
@@ -318,7 +330,11 @@ processor_process_image (zbarProcessor *self,
 
     if(n < 0)
         return(zbarErr_Set((PyObject*)self));
+#if PY_MAJOR_VERSION >= 3
+    return(PyLong_FromLong(n));
+#else
     return(PyInt_FromLong(n));
+#endif
 }
 
 void

--- a/python/scanner.c
+++ b/python/scanner.c
@@ -101,7 +101,8 @@ scanner_get_color (zbarScanner *self,
 {
     zbar_color_t zcol = zbar_scanner_get_color(self->zscn);
     assert(zcol == ZBAR_BAR || zcol == ZBAR_SPACE);
-    zbarEnumItem *color = color_enum[zcol];
+    struct module_state *st = GETMODSTATE();
+    zbarEnumItem *color = st->color_enum[zcol];
     Py_INCREF((PyObject*)color);
     return(color);
 }
@@ -155,8 +156,9 @@ scanner_scan_y (zbarScanner *self,
         return(NULL);
     if(sym == ZBAR_NONE) {
         /* hardcode most common case */
-        Py_INCREF((PyObject*)symbol_NONE);
-        return(symbol_NONE);
+        struct module_state *st = GETMODSTATE();
+        Py_INCREF((PyObject*)st->symbol_NONE);
+        return(st->symbol_NONE);
     }
     return(zbarSymbol_LookupEnum(sym));
 }

--- a/python/scanner.c
+++ b/python/scanner.c
@@ -88,7 +88,11 @@ scanner_get_width (zbarScanner *self,
                    void *closure)
 {
     unsigned int width = zbar_scanner_get_width(self->zscn);
+#if PY_MAJOR_VERSION >= 3
+    return(PyLong_FromLong(width));
+#else
     return(PyInt_FromLong(width));
+#endif
 }
 
 static zbarEnumItem*

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from distutils.core import setup, Extension
 
 setup(
     name = 'zbar',
-    version = '0.10',
+    version = '0.22.2',
     author = 'Jeff Brown',
     author_email = 'spadix@users.sourceforge.net',
     url = 'http://zbar.sourceforge.net',

--- a/python/symbol.c
+++ b/python/symbol.c
@@ -85,7 +85,8 @@ symbol_get_configs (zbarSymbol *self,
                     void *closure)
 {
     unsigned int mask = zbar_symbol_get_configs(self->zsym);
-    return(zbarEnum_SetFromMask(config_enum, mask));
+    struct module_state *st = GETMODSTATE();
+    return(zbarEnum_SetFromMask(st->config_enum, mask));
 }
 
 static PyObject*
@@ -93,7 +94,8 @@ symbol_get_modifiers (zbarSymbol *self,
                       void *closure)
 {
     unsigned int mask = zbar_symbol_get_modifiers(self->zsym);
-    return(zbarEnum_SetFromMask(modifier_enum, mask));
+    struct module_state *st = GETMODSTATE();
+    return(zbarEnum_SetFromMask(st->modifier_enum, mask));
 }
 
 static PyObject*
@@ -163,7 +165,8 @@ static zbarEnumItem*
 symbol_get_orientation (zbarSymbol *self,
                         void *closure)
 {
-    return(zbarEnum_LookupValue(orient_enum,
+    struct module_state *st = GETMODSTATE();
+    return(zbarEnum_LookupValue(st->orient_enum,
                                 zbar_symbol_get_orientation(self->zsym)));
 }
 
@@ -218,8 +221,9 @@ zbarSymbol_LookupEnum (zbar_symbol_type_t type)
 #else
     PyObject *key = PyInt_FromLong(type);
 #endif
-    zbarEnumItem *e = (zbarEnumItem*)PyDict_GetItem(symbol_enum, key);
-    if(!e) 
+    struct module_state *st = GETMODSTATE();
+    zbarEnumItem *e = (zbarEnumItem*)PyDict_GetItem(st->symbol_enum, key);
+    if(!e)
         return((zbarEnumItem*)key);
     Py_INCREF((PyObject*)e);
     Py_DECREF(key);

--- a/python/symbol.c
+++ b/python/symbol.c
@@ -105,7 +105,11 @@ symbol_get_long (zbarSymbol *self,
         val = zbar_symbol_get_quality(self->zsym);
     else
         val = zbar_symbol_get_count(self->zsym);
+#if PY_MAJOR_VERSION >= 3
+    return(PyLong_FromLong(val));
+#else
     return(PyInt_FromLong(val));
+#endif
 }
 
 static PyObject*
@@ -113,10 +117,16 @@ symbol_get_data (zbarSymbol *self,
                  void *closure)
 {
     if(!self->data) {
+#if PY_MAJOR_VERSION >= 3
+        self->data =
+            PyBytes_FromStringAndSize(zbar_symbol_get_data(self->zsym),
+                                      zbar_symbol_get_data_length(self->zsym));
+#else
         /* FIXME this could be a buffer now */
         self->data =
             PyString_FromStringAndSize(zbar_symbol_get_data(self->zsym),
                                        zbar_symbol_get_data_length(self->zsym));
+#endif
         if(!self->data)
             return(NULL);
     }
@@ -135,8 +145,13 @@ symbol_get_location (zbarSymbol *self,
         unsigned int i;
         for(i = 0; i < n; i++) {
             PyObject *x, *y;
+#if PY_MAJOR_VERSION >= 3
+            x = PyLong_FromLong(zbar_symbol_get_loc_x(self->zsym, i));
+            y = PyLong_FromLong(zbar_symbol_get_loc_y(self->zsym, i));
+#else
             x = PyInt_FromLong(zbar_symbol_get_loc_x(self->zsym, i));
             y = PyInt_FromLong(zbar_symbol_get_loc_y(self->zsym, i));
+#endif
             PyTuple_SET_ITEM(self->loc, i, PyTuple_Pack(2, x, y));
         }
     }
@@ -198,7 +213,11 @@ zbarSymbol_FromSymbol (const zbar_symbol_t *zsym)
 zbarEnumItem*
 zbarSymbol_LookupEnum (zbar_symbol_type_t type)
 {
+#if PY_MAJOR_VERSION >= 3
+    PyObject *key = PyLong_FromLong(type);
+#else
     PyObject *key = PyInt_FromLong(type);
+#endif
     zbarEnumItem *e = (zbarEnumItem*)PyDict_GetItem(symbol_enum, key);
     if(!e) 
         return((zbarEnumItem*)key);

--- a/python/zbarmodule.c
+++ b/python/zbarmodule.c
@@ -137,12 +137,6 @@ parse_dimensions (PyObject *seq,
     return(0);
 }
 
-zbarEnumItem *color_enum[2];
-zbarEnum *config_enum;
-zbarEnum *modifier_enum;
-PyObject *symbol_enum;
-zbarEnumItem *symbol_NONE;
-zbarEnum *orient_enum;
 
 static PyObject*
 version (PyObject *self,
@@ -271,11 +265,11 @@ initzbar(void)
     struct module_state *st = GETSTATE(mod);
 
     /* initialize constant containers */
-    config_enum = zbarEnum_New();
-    modifier_enum = zbarEnum_New();
-    symbol_enum = PyDict_New();
-    orient_enum = zbarEnum_New();
-    if(!config_enum || !modifier_enum || !symbol_enum || !orient_enum) {
+    st->config_enum = zbarEnum_New();
+    st->modifier_enum = zbarEnum_New();
+    st->symbol_enum = PyDict_New();
+    st->orient_enum = zbarEnum_New();
+    if(!st->config_enum || !st->modifier_enum || !st->symbol_enum || !st->orient_enum) {
         Py_DECREF(mod);
         INITERROR;
     }
@@ -309,9 +303,9 @@ initzbar(void)
     /* add types to module */
     PyModule_AddObject(mod, "EnumItem", (PyObject*)&zbarEnumItem_Type);
     PyModule_AddObject(mod, "Image", (PyObject*)&zbarImage_Type);
-    PyModule_AddObject(mod, "Config", (PyObject*)config_enum);
-    PyModule_AddObject(mod, "Modifier", (PyObject*)modifier_enum);
-    PyModule_AddObject(mod, "Orient", (PyObject*)orient_enum);
+    PyModule_AddObject(mod, "Config", (PyObject*)st->config_enum);
+    PyModule_AddObject(mod, "Modifier", (PyObject*)st->modifier_enum);
+    PyModule_AddObject(mod, "Orient", (PyObject*)st->orient_enum);
     PyModule_AddObject(mod, "Symbol", (PyObject*)&zbarSymbol_Type);
     PyModule_AddObject(mod, "SymbolSet", (PyObject*)&zbarSymbolSet_Type);
     PyModule_AddObject(mod, "SymbolIter", (PyObject*)&zbarSymbolIter_Type);
@@ -326,23 +320,23 @@ initzbar(void)
 
     /* add constants */
     PyObject *dict = PyModule_GetDict(mod);
-    color_enum[ZBAR_SPACE] =
+    st->color_enum[ZBAR_SPACE] =
         zbarEnumItem_New(dict, NULL, ZBAR_SPACE, "SPACE");
-    color_enum[ZBAR_BAR] =
+    st->color_enum[ZBAR_BAR] =
         zbarEnumItem_New(dict, NULL, ZBAR_BAR, "BAR");
 
     const enumdef *item;
     for(item = config_defs; item->strval; item++)
-        zbarEnum_Add(config_enum, item->intval, item->strval);
+        zbarEnum_Add(st->config_enum, item->intval, item->strval);
     for(item = modifier_defs; item->strval; item++)
-        zbarEnum_Add(modifier_enum, item->intval, item->strval);
+        zbarEnum_Add(st->modifier_enum, item->intval, item->strval);
     for(item = orient_defs; item->strval; item++)
-        zbarEnum_Add(orient_enum, item->intval, item->strval);
+        zbarEnum_Add(st->orient_enum, item->intval, item->strval);
 
     PyObject *tp_dict = zbarSymbol_Type.tp_dict;
     for(item = symbol_defs; item->strval; item++)
-        zbarEnumItem_New(tp_dict, symbol_enum, item->intval, item->strval);
-    symbol_NONE = zbarSymbol_LookupEnum(ZBAR_NONE);
+        zbarEnumItem_New(tp_dict, st->symbol_enum, item->intval, item->strval);
+    st->symbol_NONE = zbarSymbol_LookupEnum(ZBAR_NONE);
 
 #if PY_MAJOR_VERSION >= 3
     return mod;

--- a/python/zbarmodule.c
+++ b/python/zbarmodule.c
@@ -94,6 +94,12 @@ static const enumdef orient_defs[] = {
     { NULL, }
 };
 
+
+#if PY_MAJOR_VERSION < 3
+struct module_state zbar_state;
+#endif
+
+
 int
 object_to_bool (PyObject *obj,
                 int *val)
@@ -119,7 +125,11 @@ parse_dimensions (PyObject *seq,
         PyObject *dim = PySequence_GetItem(seq, i);
         if(!dim)
             return(-1);
+#if PY_MAJOR_VERSION >= 3
+        *dims = PyLong_AsSsize_t(dim);
+#else
         *dims = PyInt_AsSsize_t(dim);
+#endif
         Py_DECREF(dim);
         if(*dims == -1 && PyErr_Occurred())
             return(-1);
@@ -127,7 +137,6 @@ parse_dimensions (PyObject *seq,
     return(0);
 }
 
-PyObject *zbar_exc[ZBAR_ERR_NUM];
 zbarEnumItem *color_enum[2];
 zbarEnum *config_enum;
 zbarEnum *modifier_enum;
@@ -182,15 +191,56 @@ static PyMethodDef zbar_functions[] = {
     { NULL, },
 };
 
+
+#if PY_MAJOR_VERSION >= 3
+
+static int zbar_traverse(PyObject *m, visitproc visit, void *arg) {
+    Py_VISIT(GETSTATE(m)->zbar_exc[0]);
+    return 0;
+}
+
+static int zbar_clear(PyObject *m) {
+    Py_CLEAR(GETSTATE(m)->zbar_exc[0]);
+    return 0;
+}
+
+
+struct PyModuleDef zbar_moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "zbar",
+    NULL,
+    sizeof(struct module_state),
+    zbar_functions,
+    NULL,
+    zbar_traverse,
+    zbar_clear,
+    NULL
+};
+
+#define INITERROR return NULL
+
 PyMODINIT_FUNC
-initzbar (void)
+PyInit_zbar(void)
+
+#else
+#define INITERROR return
+
+PyMODINIT_FUNC
+initzbar(void)
+#endif
 {
+#if PY_MAJOR_VERSION >= 3
     /* initialize types */
+    zbarEnumItem_Type.tp_base = &PyLong_Type;
+#else
     zbarEnumItem_Type.tp_base = &PyInt_Type;
     zbarException_Type.tp_base = (PyTypeObject*)PyExc_Exception;
 
-    if(PyType_Ready(&zbarException_Type) < 0 ||
-       PyType_Ready(&zbarEnumItem_Type) < 0 ||
+    if(PyType_Ready(&zbarException_Type) < 0)
+        INITERROR;
+#endif
+
+    if(PyType_Ready(&zbarEnumItem_Type) < 0 ||
        PyType_Ready(&zbarEnum_Type) < 0 ||
        PyType_Ready(&zbarImage_Type) < 0 ||
        PyType_Ready(&zbarSymbol_Type) < 0 ||
@@ -200,23 +250,34 @@ initzbar (void)
        PyType_Ready(&zbarImageScanner_Type) < 0 ||
        PyType_Ready(&zbarDecoder_Type) < 0 ||
        PyType_Ready(&zbarScanner_Type) < 0)
-        return;
+        INITERROR;
+
+    /* initialize module */
+#if PY_MAJOR_VERSION >= 3
+    PyObject *mod = PyModule_Create(&zbar_moduledef);
+#else
+    PyObject *mod = Py_InitModule("zbar", zbar_functions);
+#endif
+    if(!mod)
+        INITERROR;
+
+#if PY_MAJOR_VERSION >= 3
+    if(PyState_AddModule(mod, &zbar_moduledef)) {
+        Py_DECREF(mod);
+        INITERROR;
+    }
+#endif
+
+    struct module_state *st = GETSTATE(mod);
 
     /* initialize constant containers */
     config_enum = zbarEnum_New();
     modifier_enum = zbarEnum_New();
     symbol_enum = PyDict_New();
     orient_enum = zbarEnum_New();
-    if(!config_enum || !modifier_enum || !symbol_enum || !orient_enum)
-        return;
-
-    zbar_exc[0] = (PyObject*)&zbarException_Type;
-    zbar_exc[ZBAR_ERR_NOMEM] = NULL;
-    zbar_error_t ei;
-    for(ei = ZBAR_ERR_INTERNAL; ei < ZBAR_ERR_NUM; ei++) {
-        zbar_exc[ei] = PyErr_NewException(exc_names[ei], zbar_exc[0], NULL);
-        if(!zbar_exc[ei])
-            return;
+    if(!config_enum || !modifier_enum || !symbol_enum || !orient_enum) {
+        Py_DECREF(mod);
+        INITERROR;
     }
 
     /* internally created/read-only type overrides */
@@ -224,10 +285,26 @@ initzbar (void)
     zbarEnum_Type.tp_setattr = NULL;
     zbarEnum_Type.tp_setattro = NULL;
 
-    /* initialize module */
-    PyObject *mod = Py_InitModule("zbar", zbar_functions);
-    if(!mod)
-        return;
+    /* zbar internal exception objects */
+#if PY_MAJOR_VERSION >= 3
+    st->zbar_exc[0] = PyErr_NewException("zbar.Exception", NULL, NULL);
+#else
+    st->zbar_exc[0] = (PyObject*)&zbarException_Type;
+#endif
+    if (st->zbar_exc[0] == NULL) {
+        Py_DECREF(mod);
+        INITERROR;
+    }
+
+    st->zbar_exc[ZBAR_ERR_NOMEM] = NULL;
+    zbar_error_t ei;
+    for(ei = ZBAR_ERR_INTERNAL; ei < ZBAR_ERR_NUM; ei++) {
+        st->zbar_exc[ei] = PyErr_NewException(exc_names[ei], st->zbar_exc[0], NULL);
+        if (!st->zbar_exc[ei]) {
+            Py_DECREF(mod);
+            INITERROR;
+        }
+    }
 
     /* add types to module */
     PyModule_AddObject(mod, "EnumItem", (PyObject*)&zbarEnumItem_Type);
@@ -244,8 +321,8 @@ initzbar (void)
     PyModule_AddObject(mod, "Scanner", (PyObject*)&zbarScanner_Type);
 
     for(ei = 0; ei < ZBAR_ERR_NUM; ei++)
-        if(zbar_exc[ei])
-            PyModule_AddObject(mod, exc_names[ei] + 5, zbar_exc[ei]);
+        if(st->zbar_exc[ei])
+            PyModule_AddObject(mod, exc_names[ei] + 5, st->zbar_exc[ei]);
 
     /* add constants */
     PyObject *dict = PyModule_GetDict(mod);
@@ -266,4 +343,29 @@ initzbar (void)
     for(item = symbol_defs; item->strval; item++)
         zbarEnumItem_New(tp_dict, symbol_enum, item->intval, item->strval);
     symbol_NONE = zbarSymbol_LookupEnum(ZBAR_NONE);
+
+#if PY_MAJOR_VERSION >= 3
+    return mod;
+#endif
+}
+
+
+PyObject*
+zbarErr_Set (PyObject *self)
+{
+    const void *zobj = ((zbarProcessor*)self)->zproc;
+    zbar_error_t err = _zbar_get_error_code(zobj);
+
+    struct module_state *st = GETMODSTATE();
+
+    if(err == ZBAR_ERR_NOMEM)
+        PyErr_NoMemory();
+    else if(err < ZBAR_ERR_NUM) {
+        PyObject *type = st->zbar_exc[err];
+        assert(type);
+        PyErr_SetObject(type, self);
+    }
+    else
+        PyErr_SetObject(st->zbar_exc[0], self);
+    return(NULL);
 }

--- a/python/zbarmodule.h
+++ b/python/zbarmodule.h
@@ -28,18 +28,40 @@
 #ifndef _ZBARMODULE_H_
 #define _ZBARMODULE_H_
 
+struct module_state {
+    PyObject *zbar_exc[ZBAR_ERR_NUM];
+};
+
+#if PY_MAJOR_VERSION < 3
 typedef struct {
     PyBaseExceptionObject base;
     PyObject *obj;
 } zbarException;
 
 extern PyTypeObject zbarException_Type;
-extern PyObject *zbar_exc[ZBAR_ERR_NUM];
+#endif
+
+
+extern struct PyModuleDef zbar_moduledef;
+
+#if PY_MAJOR_VERSION >= 3
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#define GETMODSTATE() (GETSTATE(PyState_FindModule(&zbar_moduledef)))
+#else
+extern struct module_state zbar_state;
+#define GETSTATE(m) (&zbar_state)
+#define GETMODSTATE() (&zbar_state)
+#endif
+
 
 extern PyObject *zbarErr_Set(PyObject *self);
 
 typedef struct {
+#if PY_MAJOR_VERSION >= 3
+    PyLongObject val;           /* parent type is the long type */
+#else
     PyIntObject val;            /* integer value is super type */
+#endif
     PyObject *name;             /* associated string name */
 } zbarEnumItem;
 

--- a/python/zbarmodule.h
+++ b/python/zbarmodule.h
@@ -28,9 +28,6 @@
 #ifndef _ZBARMODULE_H_
 #define _ZBARMODULE_H_
 
-struct module_state {
-    PyObject *zbar_exc[ZBAR_ERR_NUM];
-};
 
 #if PY_MAJOR_VERSION < 3
 typedef struct {
@@ -168,17 +165,21 @@ typedef struct {
 
 extern PyTypeObject zbarScanner_Type;
 
-extern zbarEnumItem *color_enum[2];
-extern zbarEnum *config_enum;
-extern zbarEnum *modifier_enum;
-extern PyObject *symbol_enum;
-extern zbarEnumItem *symbol_NONE;
-extern zbarEnum *orient_enum;
-
 extern int object_to_bool(PyObject *obj,
                           int *val);
 extern int parse_dimensions(PyObject *seq,
                             int *dims,
                             int n);
+
+
+struct module_state {
+    PyObject *zbar_exc[ZBAR_ERR_NUM];
+    zbarEnumItem *color_enum[2];
+    zbarEnum *config_enum;
+    zbarEnum *modifier_enum;
+    PyObject *symbol_enum;
+    zbarEnumItem *symbol_NONE;
+    zbarEnum *orient_enum;
+};
 
 #endif


### PR DESCRIPTION
I've ported the Python bindings to Python3.

It would be better to use use Cython instead of the raw C-API :)

I'm not sure how the buildsystem should be updated in a sensible way. When Python3 is used, one needs `--without-gtk`.

Fixes #27