### PR TITLE
python: add use_utf8 bool flag to support str and bytes on python3

### DIFF
--- a/python/symbol.c
+++ b/python/symbol.c
@@ -120,9 +120,14 @@ symbol_get_data (zbarSymbol *self,
 {
     if(!self->data) {
 #if PY_MAJOR_VERSION >= 3
-        self->data =
-            PyUnicode_FromStringAndSize(zbar_symbol_get_data(self->zsym),
-                                        zbar_symbol_get_data_length(self->zsym));
+        if(self->use_utf8)
+            self->data =
+                PyUnicode_FromStringAndSize(zbar_symbol_get_data(self->zsym),
+                                            zbar_symbol_get_data_length(self->zsym));
+        else
+            self->data =
+                PyBytes_FromStringAndSize(zbar_symbol_get_data(self->zsym),
+                                          zbar_symbol_get_data_length(self->zsym));
 #else
         /* FIXME this could be a buffer now */
         self->data =
@@ -210,6 +215,10 @@ zbarSymbol_FromSymbol (const zbar_symbol_t *zsym)
     self->zsym = zsym;
     self->data = NULL;
     self->loc = NULL;
+#if PY_MAJOR_VERSION >= 3
+    // TODO: copy value from source ZbarImage.use_utf8
+    self->use_utf8 = 1;
+#endif
     return(self);
 }
 

--- a/python/zbarmodule.h
+++ b/python/zbarmodule.h
@@ -89,6 +89,9 @@ typedef struct {
     PyObject_HEAD
     zbar_image_t *zimg;
     PyObject *data;
+#if PY_MAJOR_VERSION >= 3
+    int use_utf8;
+#endif
 } zbarImage;
 
 extern PyTypeObject zbarImage_Type;
@@ -113,6 +116,9 @@ typedef struct {
     const zbar_symbol_t *zsym;
     PyObject *data;
     PyObject *loc;
+#if PY_MAJOR_VERSION >= 3
+    int use_utf8;
+#endif
 } zbarSymbol;
 
 extern PyTypeObject zbarSymbol_Type;
@@ -153,6 +159,9 @@ typedef struct {
     zbar_decoder_t *zdcode;
     PyObject *handler;
     PyObject *args;
+#if PY_MAJOR_VERSION >= 3
+    int use_utf8;
+#endif
 } zbarDecoder;
 
 extern PyTypeObject zbarDecoder_Type;


### PR DESCRIPTION
TODO: figure out how this flag can be passed elegantly from `zbarImage` to `zbarSymbolIter` and then `zbarSymbol`. Probably with adding a `use_utf8` parameter to `zbarSymbolIter_FromSymbolSet` and then extending every class (e.g. `Processor`) to also support `use_utf8` as configuration keyword arg.

(and, not tested at all so far :D)