### PR TITLE
Bugfix: Reset conversion descriptor after close (prevent double free)

### DIFF
--- a/zbar/qrcode/qrdectxt.c
+++ b/zbar/qrcode/qrdectxt.c
@@ -409,7 +409,10 @@ int qr_code_data_list_extract_text(const qr_code_data_list *_qrlist,
       /*If eci should be reset between codes, do so.*/
       if(eci<=QR_ECI_GLI1){
         eci=-1;
-        if(eci_cd!=(iconv_t)-1)iconv_close(eci_cd);
+        if(eci_cd!=(iconv_t)-1){
+	  iconv_close(eci_cd);
+	  eci_cd=(iconv_t)-1;
+	}
       }
 
     }


### PR DESCRIPTION
I am proposing a small bugfix resolving occasional aborts of `libzbar.so` due to closing already closed _iconv_ decoder (see below).

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007f992b3af42a in __GI_abort () at abort.c:89
#2  0x00007f992b3ebc00 in __libc_message (do_abort=do_abort@entry=2, fmt=fmt@entry=0x7f992b4e0fd0 "*** Error in `%s': %s: 0x%s ***\n") at ../sysdeps/posix/libc_fatal.c:175
#3  0x00007f992b3f1fc6 in malloc_printerr (action=3, str=0x7f992b4e1048 "double free or corruption (!prev)", ptr=<optimized out>, ar_ptr=<optimized out>) at malloc.c:5049
#4  0x00007f992b3f280e in _int_free (av=0x7f992b714b00 <main_arena>, p=0x561d5a748e40, have_lock=0) at malloc.c:3905
#5  0x00007f992b39c256 in __gconv_close (cd=0x561d5a6ce000) at gconv_close.c:41
#6  0x00007f992b39baef in iconv_close (cd=<optimized out>) at iconv_close.c:35
#7  0x00007f99269823ae in qr_code_data_list_extract_text () from /usr/lib/x86_64-linux-gnu/libzbar.so.0
#8  0x00007f99269812ac in _zbar_qr_decode () from /usr/lib/x86_64-linux-gnu/libzbar.so.0
#9  0x00007f992696ebd5 in zbar_scan_image () from /usr/lib/x86_64-linux-gnu/libzbar.so.0
#10 0x00007f9926befaa8 in ffi_call_unix64 () from /usr/lib/python3.5/lib-dynload/_ctypes.cpython-35m-x86_64-linux-gnu.so
(...)
```