### PR TITLE
Add one shot mode

### DIFF
--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -130,11 +130,14 @@ static void data_handler (zbar_image_t *img, const void *userdata)
             if(fwrite(xml_buf, xml_len, 1, stdout) != 1)
                 continue;
         }
-        printf("\n");
         n++;
 
-        if(oneshot)
+        if(oneshot) {
+            if (format != RAW)
+                printf("\n");
             break;
+        } else
+            printf("\n");
     }
 
     if(format == XML && n)

--- a/zbarimg/zbarimg.c
+++ b/zbarimg/zbarimg.c
@@ -246,12 +246,16 @@ static int scan_image (const char *filename)
                     return(-1);
                 }
             }
-            printf("\n");
             found++;
             num_symbols++;
 
-            if(oneshot)
+            if(oneshot) {
+                if(xmllvl >= 0)
+                    printf("\n");
                 break;
+            }
+            else
+                printf("\n");
         }
         if(xmllvl > 2) {
             xmllvl--;


### PR DESCRIPTION
Continuous scanning can cause problems if users expect a single barcode. The same barcode can be detected and decoded twice, resulting in duplicated data in the output. Programs that consume this output must account for this.

With the new one shot mode, `zbar` programs will exit successfully after scanning exactly one barcode. 