### PR TITLE
Removing references to deprecated UIWebView

### DIFF
--- a/iphone/ZBarHelpController.m
+++ b/iphone/ZBarHelpController.m
@@ -154,14 +154,14 @@
     assert(webView);
     if(webView.loading)
         webView.hidden = YES;
-    //webView.delegate = self;
+    webView.delegate = self;
     [super viewWillAppear: animated];
 }
 
 - (void) viewWillDisappear: (BOOL) animated
 {
     [webView stopLoading];
-    //webView.delegate = nil;
+    webView.delegate = nil;
     [super viewWillDisappear: animated];
 }
 

--- a/iphone/ZBarHelpController.m
+++ b/iphone/ZBarHelpController.m
@@ -154,14 +154,12 @@
     assert(webView);
     if(webView.loading)
         webView.hidden = YES;
-    webView.delegate = self;
     [super viewWillAppear: animated];
 }
 
 - (void) viewWillDisappear: (BOOL) animated
 {
     [webView stopLoading];
-    webView.delegate = nil;
     [super viewWillDisappear: animated];
 }
 

--- a/iphone/ZBarHelpController.m
+++ b/iphone/ZBarHelpController.m
@@ -84,11 +84,11 @@
     view.autoresizingMask = (UIViewAutoresizingFlexibleWidth |
                              UIViewAutoresizingFlexibleHeight);
 
-    webView = [[UIWebView alloc]
+    webView = [[WKWebView alloc]
                   initWithFrame: CGRectMake(0, 0,
                                             bounds.size.width,
                                             bounds.size.height - 44)];
-    webView.delegate = self;
+    //webView.delegate = self;
     webView.backgroundColor = [UIColor colorWithWhite: .125f
                                        alpha: 1];
     webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth |
@@ -154,14 +154,14 @@
     assert(webView);
     if(webView.loading)
         webView.hidden = YES;
-    webView.delegate = self;
+    //webView.delegate = self;
     [super viewWillAppear: animated];
 }
 
 - (void) viewWillDisappear: (BOOL) animated
 {
     [webView stopLoading];
-    webView.delegate = nil;
+    //webView.delegate = nil;
     [super viewWillDisappear: animated];
 }
 
@@ -210,7 +210,7 @@
         [self dismissModalViewControllerAnimated: YES];
 }
 
-- (void) webViewDidFinishLoad: (UIWebView*) view
+- (void) webViewDidFinishLoad: (WKWebView*) view
 {
     if(view.hidden) {
         [view stringByEvaluatingJavaScriptFromString:
@@ -234,9 +234,9 @@
     }
 }
 
-- (BOOL)             webView: (UIWebView*) view
+- (BOOL)             webView: (WKWebView*) view
   shouldStartLoadWithRequest: (NSURLRequest*) req
-              navigationType: (UIWebViewNavigationType) nav
+              navigationType: (WKNavigationType) nav
 {
     NSURL *url = [req URL];
     if([url isFileURL])

--- a/iphone/include/ZBarSDK/ZBarHelpController.h
+++ b/iphone/include/ZBarSDK/ZBarHelpController.h
@@ -22,6 +22,7 @@
 //------------------------------------------------------------------------
 
 #import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 
 @class ZBarHelpController;
 
@@ -36,12 +37,12 @@
 // failure dialog w/a few useful tips
 
 @interface ZBarHelpController : UIViewController
-                              < UIWebViewDelegate,
+                              < WKNavigationDelegate,
                                 UIAlertViewDelegate >
 {
     NSString *reason;
     id delegate;
-    UIWebView *webView;
+    WKWebView *webView;
     UIToolbar *toolbar;
     UIBarButtonItem *doneBtn, *backBtn, *space;
     NSURL *linkURL;


### PR DESCRIPTION
...to use WKWebView instead.

  Library rebuilt and tested on iPhone X, using iOS 13.1.3.  All buttons and links tested, and 'Done' dismissal button also exercised.