### PR TITLE
Mention Python 3 support in Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ available at:
 
 **Python bindings**
 
-The Python bindings require Python 2 and provide only non-GUI functions.
+The Python bindings require Python 2 or 3 and provide only non-GUI functions.
 You will need Python and PIL or Pillow if you would like to scan images or
 video directly using Python. Python is available from:
 


### PR DESCRIPTION
Since Python 3 is actually supported now, it's misleading to say "requires Python 2" here.