### PR TITLE
zbarcam: when reading raw, set stdout to binary mode on windows

### DIFF
--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -132,6 +132,10 @@ static void data_handler (zbar_image_t *img, const void *userdata)
                 continue;
         }
         else if(format == RAW) {
+#ifdef _WIN32
+            _setmode(_fileno(stdout), _O_BINARY);
+#endif
+
             if(fwrite(zbar_symbol_get_data(sym),
                       zbar_symbol_get_data_length(sym),
                       1, stdout) != 1)


### PR DESCRIPTION
Prevents Windows from attempting to convert LF to CRLF on raw data.

Fixes #97 