### PR TITLE
zbarcam: minor code cleanup and improvement

### DIFF
--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -132,10 +132,6 @@ static void data_handler (zbar_image_t *img, const void *userdata)
                 continue;
         }
         else if(format == RAW) {
-#ifdef _WIN32
-            _setmode(_fileno(stdout), _O_BINARY);
-#endif
-
             if(fwrite(zbar_symbol_get_data(sym),
                       zbar_symbol_get_data_length(sym),
                       1, stdout) != 1)
@@ -312,11 +308,17 @@ int main (int argc, const char *argv[])
        (display && zbar_processor_set_visible(proc, 1)))
         return(zbar_processor_error_spew(proc, 0));
 
-    if(format == XML) {
 #ifdef _WIN32
+    if(format == XML || format == RAW) {
         fflush(stdout);
-        _setmode(_fileno(stdout), _O_BINARY);
+        if(_setmode(_fileno(stdout), _O_BINARY) == -1) {
+            fprintf(stderr, "ERROR: failed to set stdout mode: %i\n\n", errno);
+            return(usage(1));
+        }
+    }
 #endif
+
+    if(format == XML) {
         printf(xml_head, video_device);
         fflush(stdout);
     }

--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -312,8 +312,8 @@ int main (int argc, const char *argv[])
     if(format == XML || format == RAW) {
         fflush(stdout);
         if(_setmode(_fileno(stdout), _O_BINARY) == -1) {
-            fprintf(stderr, "ERROR: failed to set stdout mode: %i\n\n", errno);
-            return(usage(1));
+            fprintf(stderr, "ERROR: failed to set stdout mode: %i\n", errno);
+            return 1;
         }
     }
 #endif

--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -313,7 +313,7 @@ int main (int argc, const char *argv[])
         fflush(stdout);
         if(_setmode(_fileno(stdout), _O_BINARY) == -1) {
             fprintf(stderr, "ERROR: failed to set stdout mode: %i\n", errno);
-            return 1;
+            return(1);
         }
     }
 #endif

--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -132,6 +132,10 @@ static void data_handler (zbar_image_t *img, const void *userdata)
                 continue;
         }
         else if(format == RAW) {
+#ifdef _WIN32
+            _setmode(_fileno(stdout), _O_BINARY);
+#endif
+
             if(fwrite(zbar_symbol_get_data(sym),
                       zbar_symbol_get_data_length(sym),
                       1, stdout) != 1)

--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -132,10 +132,6 @@ static void data_handler (zbar_image_t *img, const void *userdata)
                 continue;
         }
         else if(format == RAW) {
-#ifdef _WIN32
-            _setmode(_fileno(stdout), _O_BINARY);
-#endif
-
             if(fwrite(zbar_symbol_get_data(sym),
                       zbar_symbol_get_data_length(sym),
                       1, stdout) != 1)


### PR DESCRIPTION
On the recommendation of @jasp00, I've made some improvements to my Windows CRLF PR earlier. Now it re-uses the same call used before when `format == XML` in `main()` instead of making a separate one and it also performs an error check if `_setmode` fails for whatever reason.