### PR TITLE
Update zbargtk.c

### DIFF
--- a/gtk/zbargtk.c
+++ b/gtk/zbargtk.c
@@ -264,7 +264,6 @@ static gboolean zbar_processing_idle_callback(gpointer data)
 
             if(zbar_video_enable(zbar->video, 0)) {
                 zbar_video_error_spew(zbar->video, 0);
-                zbar->video_enabled_state = FALSE;
             }
 
             zbar_image_scanner_enable_cache(zbar->scanner, 0);


### PR DESCRIPTION
There's no need to assign zbar->video_enabled_state. The function should have returned if video_enabled_state is not false.