### PR TITLE
ClientMessage event without KeyPress handler

### DIFF
--- a/zbar/processor/x.c
+++ b/zbar/processor/x.c
@@ -67,6 +67,7 @@ static inline int x_handle_event (zbar_processor_t *proc)
             zprintf(3, "WM_DELETE_WINDOW\n");
             return(_zbar_processor_handle_input(proc, -1));
         }
+        break;
 
     case KeyPress: {
         KeySym key = XLookupKeysym(&ev.xkey, 0);


### PR DESCRIPTION
It looks much like a typo. Should be tested properly before merge