### PR TITLE
zbarcam/zbar{cam,img}.c: fix build with musl

### DIFF
--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -36,6 +36,7 @@
 
 #ifdef ENABLE_NLS
 # include <libintl.h>
+# include <locale.h>
 # define _(string) gettext(string)
 #else
 # define _(string) string

--- a/zbarimg/zbarimg.c
+++ b/zbarimg/zbarimg.c
@@ -41,6 +41,7 @@
 
 #ifdef ENABLE_NLS
 # include <libintl.h>
+# include <locale.h>
 # define _(string) gettext(string)
 #else
 # define _(string) string


### PR DESCRIPTION
setlocale is used since version 0.23.1 and https://git.linuxtv.org/zbar.git/commit/id=d05911f8d5fb8c1e064bd93ed9ec9f038c5da096

Include locale.h to avoid the following build failure on musl:

```
zbarcam/zbarcam.c:168:5: warning: implicit declaration of function 'setlocale'; did you mean 'setstate'? [-Wimplicit-function-declaration]
     setlocale (LC_ALL, "");
     ^~~~~~~~~
     setstate
zbarcam/zbarcam.c:168:16: error: 'LC_ALL' undeclared (first use in this function)
     setlocale (LC_ALL, "");
                ^~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/b93ce5430bf22ddda94ee30882a883348617f5b1

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>