### PR TITLE
qt5: Add missing builddir subdirectories

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,43 @@
+name: Ubuntu pbuilder CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: prepare
+      run:
+        sudo apt install -y autopoint debian-archive-keyring dpkg gettext builder
+    - name: pbulder_prepare
+      run: |
+        export BASETGZ="$HOME/pbuilder-bases/debian-sid-$TARGET_ARCH.tgz"
+        MIRROR=http://cdn-fastly.deb.debian.org/debian
+        KEYRING=/usr/share/keyrings/debian-archive-keyring.gpg
+        if [ ! -e "$BASETGZ.stamp" ]; then
+          mkdir -p "$HOME/pbuilder-bases"
+          sudo pbuilder --create --basetgz "$BASETGZ" --mirror $MIRROR \
+            --distribution sid --architecture $TARGET_ARCH \
+            --debootstrapopts --variant=buildd \
+            --debootstrapopts --keyring=$KEYRING \
+            --debootstrapopts --include=perl
+          touch "$BASETGZ.stamp"
+        else
+          sudo pbuilder --update --basetgz "$BASETGZ"
+        fi
+    - name: src_archive
+      run:
+        git archive --format tgz -o ../zbar_$(more configure.ac |grep AC_INIT|perl -ne 'print $1 if /(\d+.\d+)/').orig.tar.gz HEAD
+
+    - name: build
+      run: |
+        DIR="$PWD"
+        cd ..
+        dpkg-source -b "$DIR"
+        env -i CC="$CC" CXX="$CXX" sudo pbuilder --build --debbuildopts --jobs=auto --basetgz "$BASETGZ" *.dsc

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: prepare
       run:
-        sudo apt install -y autopoint debian-archive-keyring dpkg gettext builder
+        sudo apt-get install -y autopoint debian-archive-keyring dpkg gettext builder
     - name: pbulder_prepare
       run: |
         export BASETGZ="$HOME/pbuilder-bases/debian-sid-$TARGET_ARCH.tgz"

--- a/qt/Makefile.am.inc
+++ b/qt/Makefile.am.inc
@@ -15,4 +15,5 @@ qt/moc_%.cpp: qt/%.h
 	$(MOC) $(qt_libzbarqt_la_CPPFLAGS) $< -o $@
 
 qt/moc_%.cpp: include/zbar/%.h
+	$(mkdir_p) qt
 	$(MOC) $(qt_libzbarqt_la_CPPFLAGS) $< -o $@

--- a/zbarcam/Makefile.am.inc
+++ b/zbarcam/Makefile.am.inc
@@ -28,6 +28,7 @@ DISTCLEANFILES += $(nodist_zbarcam_zbarcam_qt_SOURCES) zbarcam/moc_zbarcam_qt.h
 
 
 zbarcam/moc_zbarcam_qt.h: zbarcam/zbarcam-qt.cpp
+	$(mkdir_p) zbarcam
 	$(MOC) -i $(zbarcam_zbarcam_qt_CPPFLAGS) $< -o $@
 endif
 


### PR DESCRIPTION
Missing subdirs when compiling with --with-qt5 option.