### PR TITLE
Include dbus/org.linuxtv.Zbar.conf in EXTRA_DIST unconditionally

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,10 +90,10 @@ endif
 if HAVE_DBUS
 dbusconfdir = @DBUS_CONFDIR@
 dbusconf_DATA = $(srcdir)/dbus/org.linuxtv.Zbar.conf
-EXTRA_DIST += $(dbusconf_DATA)
 endif
 
-EXTRA_DIST += zbar.ico zbar.nsi zbar-qt5.pc.in zbar-qt.pc.in
+EXTRA_DIST += zbar.ico zbar.nsi zbar-qt5.pc.in zbar-qt.pc.in \
+    dbus/org.linuxtv.Zbar.conf
 
 EXTRA_DIST += examples/*.png examples/sha1sum \
     examples/upcrpc.py examples/upcrpc.pl \


### PR DESCRIPTION
This patch fixes include always in dist tar ball by add dbus/org.linuxtv.Zbar.conf