### PR TITLE
Fix "__assert_fail" issue

### DIFF
--- a/examples/scan_image.cpp
+++ b/examples/scan_image.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
-#include <Magick++.h>
 #include <zbar.h>
+#include <Magick++.h>
 #define STR(s) #s
 
 using namespace std;


### PR DESCRIPTION
Putting Magick header after zbar solves the "__assert_fail’ was not declared in this scope" issue, that may occur:

https://stackoverflow.com/questions/43678937/c-boost-and-imagemagick-api-issue