### PR TITLE
configure.ac: Fix a few bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,11 +191,14 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        arch: [x86_64]
+        arch: [x86_64, i686]
         include:
           - arch: x86_64
             msystem: MINGW64
             grep: x86-64
+          - arch: i686
+            msystem: MINGW32
+            grep: 386
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, i686]
+        video: [VfW, DShow]
         include:
           - arch: x86_64
             msystem: MINGW64
@@ -199,6 +200,10 @@ jobs:
           - arch: i686
             msystem: MINGW32
             grep: 386
+          - video: DShow
+            extra: --with-directshow
+          - video: VfW
+            extra:
     defaults:
       run:
         shell: msys2 {0}
@@ -222,7 +227,7 @@ jobs:
       shell: msys2 {0}
       run: |
         autoreconf -vfi
-        ./configure --enable-pthread --disable-dependency-tracking ${{ matrix.cam }}
+        ./configure --enable-pthread --disable-dependency-tracking ${{ matrix.extra }}
 
     - name: build
       shell: msys2 {0}


### PR DESCRIPTION
- There's no need to check for gtk.h header. The cause of Gtk
  detection failures were due to the lack of a '[' at the test line;
- The xmlto detection got broken after recent changes;
- there's an extra space at the code which sets qt5 to no.

Signed-off-by: Mauro Carvalho Chehab <mchehab+huawei@kernel.org>