### PR TITLE
Function stdcall declaration issue in Windows.

### DIFF
--- a/zbar/thread.h
+++ b/zbar/thread.h
@@ -35,7 +35,7 @@
 # define HAVE_THREADS
 # define ZTHREAD DWORD WINAPI
 
-typedef ZTHREAD (zbar_thread_proc_t)(void*);
+typedef DWORD (WINAPI zbar_thread_proc_t)(void*);
 
 typedef DWORD zbar_thread_id_t;
 


### PR DESCRIPTION
In Visual Studio, the call convention keyword stdcall or WINAPI must be enclosed in parentheses. the declaration must be
```
typedef DWORD (WINAPI zbar_thread_proc_t)(void*);
```
and can `NOT` be
```
typedef DWORD WINAPI (zbar_thread_proc_t)(void*);
```

Signed-off-by: ssrlive ssrlivebox@gmail.com