### PR TITLE
Fixing compiling error in Visual studio

### DIFF
--- a/zbar/processor/win.c
+++ b/zbar/processor/win.c
@@ -22,6 +22,7 @@
  *------------------------------------------------------------------------*/
 
 #include <assert.h>
+#include <WinSock2.h>
 #include <windows.h>
 #include "processor.h"
 

--- a/zbar/processor/win.c
+++ b/zbar/processor/win.c
@@ -22,7 +22,9 @@
  *------------------------------------------------------------------------*/
 
 #include <assert.h>
+#if defined(_MSC_VER)
 #include <WinSock2.h>
+#endif
 #include <windows.h>
 #include "processor.h"
 


### PR DESCRIPTION
Likes `error C2375: 'connect' : redefinition; different linkage`. see [this link](https://stackoverflow.com/questions/11726958/cant-include-winsock2-h-in-msvc-2010)
