### PR TITLE
Enforce x11 backend even on wayland

### DIFF
--- a/zbarcam/zbarcam-gtk.c
+++ b/zbarcam/zbarcam-gtk.c
@@ -133,6 +133,7 @@ int main(int argc, char *argv[])
 {
     const char *video_arg = NULL;
 
+    gdk_set_allowed_backends("x11,*");
     gtk_init(&argc, &argv);
 
     if (argc > 1)


### PR DESCRIPTION
There is currently no output delivered when using wayland. This is
equivalent to using `export GDB_BACKEND=x11`.