### PR TITLE
Fix .pdf gotcha

### DIFF
--- a/zbarimg/zbarimg.c
+++ b/zbarimg/zbarimg.c
@@ -167,6 +167,10 @@ static int scan_image(const char *filename)
 
     int found	       = 0;
     MagickWand *images = NewMagickWand();
+
+    // default is a measly 72dpi for pdf
+    MagickSetResolution(images, 900, 900);
+
     if (!MagickReadImage(images, filename) && dump_error(images))
 	return (-1);
 


### PR DESCRIPTION
PDF does not inherently encode a resolution--it's essentially a vector format. By default, ImageMagick samples it at a *tiny* 72dpi resolution, so many QR codes are not read.

Default .pdf to 300dpi sample rate to fix the issue.