### PR TITLE
python: enum: fix build for Python 3.11

### DIFF
--- a/python/enum.c
+++ b/python/enum.c
@@ -50,7 +50,11 @@ static zbarEnumItem *enumitem_new(PyTypeObject *type, PyObject *args,
 
     /* we assume the "fast path" for a single-digit ints (see longobject.c) */
     /* this also holds if we get a small_int preallocated long */
+#if PY_VERSION_HEX >= 0x030900A4
+    Py_SET_SIZE(&self->val, Py_SIZE(longval));
+#else
     Py_SIZE(&self->val)	  = Py_SIZE(longval);
+#endif
     self->val.ob_digit[0] = longval->ob_digit[0];
     Py_DECREF(longval);
 #else
@@ -129,7 +133,11 @@ zbarEnumItem *zbarEnumItem_New(PyObject *byname, PyObject *byvalue, int val,
 
     /* we assume the "fast path" for a single-digit ints (see longobject.c) */
     /* this also holds if we get a small_int preallocated long */
+#if PY_VERSION_HEX >= 0x030900A4
+    Py_SET_SIZE(&self->val, Py_SIZE(longval));
+#else
     Py_SIZE(&self->val)	  = Py_SIZE(longval);
+#endif
     self->val.ob_digit[0] = longval->ob_digit[0];
     Py_DECREF(longval);
 


### PR DESCRIPTION
Python 3.9 introduced Py_SET_SIZE function to set size instead of relying on Py_SIZE() as a macro [3.9].

Python 3.10 started to encourage to use Py_SET_SIZE instead of assigning into return value of Py_SIZE [3.10].

Python 3.11 flips the switch, turn Py_SIZE into a function [3.11], thus Py_SIZE(obj) will be a rvalue. We need to use Py_SET_SIZE to set size now.

[3.9]: https://docs.python.org/3.9/c-api/structures.html#c.Py_SET_SIZE
[3.10]: https://docs.python.org/3.10/c-api/structures.html#c.Py_SIZE
[3.11]: https://docs.python.org/3.11/c-api/structures.html#c.Py_SIZE