### PR TITLE
Remove nonexistent zbar-qt.pc.in file from EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,7 +92,7 @@ dbusconfdir = @DBUS_CONFDIR@
 dbusconf_DATA = $(srcdir)/dbus/org.linuxtv.Zbar.conf
 endif
 
-EXTRA_DIST += zbar.ico zbar.nsi zbar-qt5.pc.in zbar-qt.pc.in \
+EXTRA_DIST += zbar.ico zbar.nsi zbar-qt5.pc.in \
     dbus/org.linuxtv.Zbar.conf
 
 EXTRA_DIST += examples/*.png examples/sha1sum \


### PR DESCRIPTION
Commit 4703c4e ("configure.ac: drop support for Qt4") removed the zbar-qt.pc.in file from the tree, but did not remove it from the EXTRA_DIST list of files, thereby causing "make dist" to fail with the error:

  No rule to make target 'zbar-qt.pc.in', needed by 'distdir-am'.

Fix by removing this nonexistent file from EXTRA_DIST.

Fixes: #251 