### PR TITLE
Fix memory recycle bug of empty symbols

### DIFF
--- a/zbar/img_scanner.c
+++ b/zbar/img_scanner.c
@@ -230,7 +230,7 @@ inline zbar_symbol_t *_zbar_image_scanner_alloc_sym(zbar_image_scanner_t *iscn,
 	if (datalen <= 1 << (i * 2))
 	    break;
 
-    for (; i > 0; i--)
+    for (; i >= 0; i--)
 	if ((sym = iscn->recycle[i].head)) {
 	    STAT(sym_recycle[i]);
 	    break;


### PR DESCRIPTION
For full background of this PR, see #258 

Shortly:

The 0:th bucket in the `iscn->recycle` array holds a list of recycled `zbar_symbol_t` with the `data_alloc` set to 0.

When a 0-sized symbol is requested, the first loop will exit with `i=0` which makes sense (since these are in the 0:th index in the `recycle` array):
```c
    for (i = 0; i < RECYCLE_BUCKETS - 1; i++)
	if (datalen <= 1 << (i * 2))
	    break;
```
But then the next for-loop will never enter, as `i > 0` is false:
```c
    for (; i > 0; i--)
	if ((sym = iscn->recycle[i].head)) {
	    STAT(sym_recycle[i]);
	    break;
	}
```
This means that `sym` will still be zero, and a new symbol will be allocated:
```c
    } else {
	sym = calloc(1, sizeof(zbar_symbol_t));
	STAT(sym_new);
    }
```