### PR TITLE
Fix flag to compile under Windows with Visual Studio

### DIFF
--- a/zbar/processor.h
+++ b/zbar/processor.h
@@ -25,11 +25,13 @@
 
 #include "config.h"
 #ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
+# include <inttypes.h>
+#endif
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
 #endif
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <zbar.h>
 #include "error.h"


### PR DESCRIPTION
Visual Studio doesn't have the include file _unistd.h_ and without the define flag the compilation fails