### PR TITLE
Add XML bounding box

### DIFF
--- a/zbar/symbol.c
+++ b/zbar/symbol.c
@@ -423,6 +423,16 @@ char *zbar_symbol_xml(const zbar_symbol_t *sym, char **buf, unsigned *len)
     TMPL_FMT("<symbol type='%s' quality='%d' orientation='%s'", type,
 	     sym->quality, orient);
 
+    if (sym->npts) {
+	int j;
+	TMPL_COPY(" bbox='");
+	for (j=0; j< sym->npts;j++)
+		TMPL_FMT("%d,%d ",sym->pts[j].x,sym->pts[j].y);
+	/* cleanup trailing space */
+	n--;
+	TMPL_COPY("'");
+    }
+
     if (mods) {
 	int j;
 	TMPL_COPY(" modifiers='");


### PR DESCRIPTION
Add bounding box information to xml output.

This is useful if you want to create hyperlinks around QR codes on displayed images and need the location.
It is also needed information if you want to remove QR code from shown on PDF's by drawing a black box over them.