### PR TITLE
qrdectxt: Fix Big5 pre-validation

### DIFF
--- a/zbar/qrcode/qrdectxt.c
+++ b/zbar/qrcode/qrdectxt.c
@@ -46,8 +46,10 @@ static int text_is_big5(const unsigned char *_text, int _len)
 {
     int i;
     for (i = 0; i < _len; i++) {
-	if (_text[i] == 0xFF)
+	if (_text[i] == 0xFF || _text[i] == 0x80) // not possible in Big5
 	    return 0;
+	else if (_text[i] <= 0x7F) // accept mix with single-byte ASCII
+		continue;
 	else if (_text[i] >= 0x81) { // possible Big5 start byte
 	    int w = _text[i] << 8;
 	    if (++i == _len) // second byte does not exist
@@ -64,8 +66,8 @@ static int text_is_big5(const unsigned char *_text, int _len)
 	        (w >= 0xC6A1 && w <= 0xC8FE) ||
 	        (w >= 0xF9D6 && w <= 0xFEFE))
 		    continue;
+	    /* otherwise not valid Big5 double-character */
 	    return 0;
-	} else { // normal ascii encoding, it's okay
 	}
     }
     return 1;

--- a/zbar/qrcode/qrdectxt.c
+++ b/zbar/qrcode/qrdectxt.c
@@ -48,14 +48,23 @@ static int text_is_big5(const unsigned char *_text, int _len)
     for (i = 0; i < _len; i++) {
 	if (_text[i] == 0xFF)
 	    return 0;
-	else if (_text[i] >= 0x80) { // first byte is big5
-	    i++;
-	    if (i >= _len) // second byte not exists
+	else if (_text[i] >= 0x81) { // possible Big5 start byte
+	    int w = _text[i] << 8;
+	    if (++i == _len) // second byte does not exist
 		return 0;
-	    if (_text[i] < 0x40 || (_text[i] > 0x7E && _text[i] < 0xA1) ||
-		_text[i] > 0xFE) { // second byte not in range
-		return 0;
-	    }
+	    w |= _text[i];
+	    /* non user-defined ranges */
+	    if ((w >= 0xA140 && w <= 0xA3BF) ||
+	        (w >= 0xA3C0 && w <= 0xA3FE) ||
+	        (w >= 0xA440 && w <= 0xC67E) ||
+	        (w >= 0xC940 && w <= 0xF9D5))
+		    continue;
+	    /* user-defined ranges */
+	    if ((w >= 0x8140 && w <= 0xA0FE) ||
+	        (w >= 0xC6A1 && w <= 0xC8FE) ||
+	        (w >= 0xF9D6 && w <= 0xFEFE))
+		    continue;
+	    return 0;
 	} else { // normal ascii encoding, it's okay
 	}
     }


### PR DESCRIPTION
The second byte was checked independently of the first, which leaves a checkerboard of false positives and negatives.

Note that I separated the user-defined ranges from the non-user-defined ranges for possible future enhancements (like only using the latter) but they are both treated the same.