### PR TITLE
Fix pointer wrap around undefined behavior

### DIFF
--- a/zbar/img_scanner.c
+++ b/zbar/img_scanner.c
@@ -33,6 +33,7 @@
 #endif
 
 #include <assert.h>
+#include <stddef.h>
 #include <stdlib.h> /* malloc, free */
 #include <string.h> /* memcmp, memset, memcpy */
 
@@ -50,7 +51,7 @@
 #include "svg.h"
 
 #if 1
-#define ASSERT_POS assert(p == data + x + y * (intptr_t)w)
+#define ASSERT_POS assert(p == data + x + y * (ptrdiff_t)w)
 #else
 #define ASSERT_POS
 #endif
@@ -858,11 +859,11 @@ static void zbar_send_code_via_dbus(zbar_image_scanner_t *iscn,
 }
 #endif
 
-#define movedelta(dx, dy)                \
-    do {                                 \
-	x += (dx);                       \
-	y += (dy);                       \
-	p += (dx) + ((uintptr_t)(dy)*w); \
+#define movedelta(dx, dy)                  \
+    do {                                   \
+        x += (dx);                         \
+        y += (dy);                         \
+        p += (dx) + ((dy)*(ptrdiff_t)(w)); \
     } while (0);
 
 static void *_zbar_scan_image(zbar_image_scanner_t *iscn, zbar_image_t *img)


### PR DESCRIPTION
https://github.com/mchehab/zbar/blob/a549566ea11eb03622bd4458a1728ffe3f589163/zbar/img_scanner.c#L965
https://github.com/mchehab/zbar/blob/a549566ea11eb03622bd4458a1728ffe3f589163/zbar/img_scanner.c#L861-L866

This expression `movedelta(-1, 0);` is expanded to
```c
p += (-1) + ((uintptr_t)(0) * w);
```
where the RHS is evaluated unsigned as `(uintptr_t) -1` i.e. 0xfff...

This pointer addition with unsigned wrap around is an undefined behavior in C.

In the latest clang trunk, the expr is optimized as a constant assignment ( `p = -1;` ), and segfault in runtime.
https://godbolt.org/z/G8xeMWTo5

This PR fixes the issue by casting the unsigned variable `w` to a signed type `ptrdiff_t`.
Given that dx and dy are both int, the RHS expression is evaluated as signed -1.