### PR TITLE
symbol: Fix base64_encode to correctly encode bytes above 0x7F

### DIFF
--- a/zbar/symbol.c
+++ b/zbar/symbol.c
@@ -315,11 +315,11 @@ unsigned base64_encode(char *dst, const char *src, unsigned srclen)
     char *start = dst;
     int nline	= 19;
     for (; srclen; srclen -= 3) {
-	unsigned int buf = *(src++) << 16;
+	unsigned int buf = ((unsigned char)*(src++)) << 16;
 	if (srclen > 1)
-	    buf |= *(src++) << 8;
+	    buf |= ((unsigned char)*(src++)) << 8;
 	if (srclen > 2)
-	    buf |= *(src++);
+	    buf |= ((unsigned char)*(src++));
 	*(dst++) = alphabet[(buf >> 18) & 0x3f];
 	*(dst++) = alphabet[(buf >> 12) & 0x3f];
 	*(dst++) = (srclen > 1) ? alphabet[(buf >> 6) & 0x3f] : '=';


### PR DESCRIPTION
Fix a bug in base64_encode() function that was incorrectly encoding bytes with the most-significant bit set in the second or third byte of a 3-byte group.

This was due to the use of signed `char` types in the bit-shifting expressions resulting in signed-extension causing all of the bits of the previous bytes to be overwritten with 1's.

This fixes the problem by first casting the values to `unsigned char` so that the bit-shift, which promotes the type to `int`, does not do signed-integer extension.

This fixes the problem by first casting the values to `unsigned char` so that the bit-shift, which promotes the type to `int`, does not do signed-integer extension.

Fixes https://github.com/mchehab/zbar/issues/310